### PR TITLE
various fixes

### DIFF
--- a/src/__tests__/01.basic.ts
+++ b/src/__tests__/01.basic.ts
@@ -21,21 +21,12 @@ test('01.basic', () => {
  * a test schema definition
  */
 export interface TestSchema {
-  /**
-   * count
-   */
   count?: number;
-  /**
-   * dateCreated
-   */
   dateCreated?: Date;
   /**
    * Test Schema Name
    */
   name?: string;
-  /**
-   * propertyName1
-   */
   propertyName1: boolean;
 }`);
 
@@ -60,21 +51,9 @@ export interface TestSchema {
  * an Array test schema definition
  */
 export interface ArrayObject {
-  /**
-   * count
-   */
   count?: number[];
-  /**
-   * dateCreated
-   */
   dateCreated?: Date[];
-  /**
-   * name
-   */
   name?: string[];
-  /**
-   * propertyName1
-   */
   propertyName1: boolean[];
 }`);
 });

--- a/src/__tests__/02.fromFile.ts
+++ b/src/__tests__/02.fromFile.ts
@@ -35,13 +35,7 @@ export * from './Readme';
  * a test schema definition
  */
 export interface TestSchema {
-  /**
-   * name
-   */
   name?: string;
-  /**
-   * propertyName1
-   */
   propertyName1: boolean;
 }
 `
@@ -54,9 +48,6 @@ export interface TestSchema {
  * Do not modify this file manually
  */
 
-/**
- * Bar
- */
 export interface Bar {
   /**
    * Id
@@ -64,9 +55,6 @@ export interface Bar {
   id: number;
 }
 
-/**
- * Foo
- */
 export interface Foo {
   /**
    * Bar
@@ -86,17 +74,8 @@ export interface Foo {
  * Do not modify this file manually
  */
 
-/**
- * Job
- */
 export interface Job {
-  /**
-   * businessName
-   */
   businessName: string;
-  /**
-   * jobTitle
-   */
   jobTitle: string;
 }
 
@@ -105,17 +84,8 @@ export interface Job {
  */
 export type People = Person[];
 
-/**
- * Person
- */
 export interface Person {
-  /**
-   * firstName
-   */
   firstName: string;
-  /**
-   * job
-   */
   job?: Job;
   /**
    * Last Name

--- a/src/__tests__/03.array.ts
+++ b/src/__tests__/03.array.ts
@@ -18,13 +18,7 @@ test('03.array', async () => {
  * Do not modify this file manually
  */
 
-/**
- * Item
- */
 export interface Item {
-  /**
-   * name
-   */
   name: string;
 }
 
@@ -32,17 +26,8 @@ export interface Item {
  * a test schema definition
  */
 export interface Test {
-  /**
-   * items
-   */
   items?: Item[];
-  /**
-   * name
-   */
   name?: string;
-  /**
-   * propertyName1
-   */
   propertyName1: boolean;
 }
 

--- a/src/__tests__/04.multipleFiles.ts
+++ b/src/__tests__/04.multipleFiles.ts
@@ -21,9 +21,6 @@ test('04.multipleFiles', async () => {
 
 import { Person } from '.';
 
-/**
- * Item
- */
 export interface Item {
   /**
    * Female Zebra
@@ -33,9 +30,6 @@ export interface Item {
    * Male Zebra
    */
   maleZebra?: Zebra;
-  /**
-   * name
-   */
   name: string;
 }
 
@@ -48,27 +42,15 @@ export type People = Person[];
  * a test schema definition
  */
 export interface Test {
-  /**
-   * name
-   */
   name?: string;
   /**
    * A list of People
    */
   people?: People;
-  /**
-   * propertyName1
-   */
   propertyName1: boolean;
 }
 
-/**
- * Zebra
- */
 export interface Zebra {
-  /**
-   * name
-   */
   name?: string;
 }
 `

--- a/src/__tests__/05.enum.ts
+++ b/src/__tests__/05.enum.ts
@@ -23,13 +23,7 @@ test('05.enums', () => {
  * a test schema definition
  */
 export interface TestSchema {
-  /**
-   * bottomColour
-   */
   bottomColour: 'red' | 'green' | 'orange' | 'blue';
-  /**
-   * topColour
-   */
   topColour: 'red' | 'green' | 'orange' | 'blue';
 }`);
 });

--- a/src/__tests__/06.alternatives.ts
+++ b/src/__tests__/06.alternatives.ts
@@ -23,13 +23,7 @@ test('06.alternatives', async () => {
  */
 export type Basic = number | string;
 
-/**
- * Other
- */
 export interface Other {
-  /**
-   * other
-   */
   other?: string;
 }
 
@@ -37,13 +31,7 @@ export interface Other {
  * a test schema definition
  */
 export interface Test {
-  /**
-   * name
-   */
   name?: string;
-  /**
-   * value
-   */
   value?: Thing | Other;
   /**
    * a description for basic
@@ -56,13 +44,7 @@ export interface Test {
  */
 export type TestList = (boolean | string)[];
 
-/**
- * Thing
- */
 export interface Thing {
-  /**
-   * thing
-   */
   thing: string;
 }
 `

--- a/src/__tests__/07/AssertionCriteria.ts
+++ b/src/__tests__/07/AssertionCriteria.ts
@@ -8,9 +8,6 @@ export class AssertionCriteria {
 
   private static oneContentGeneratedModel = `
 
-/**
- * Item
- */
 export interface Item {
   /**
    * Female Zebra
@@ -20,9 +17,6 @@ export interface Item {
    * Male Zebra
    */
   maleZebra?: Zebra;
-  /**
-   * name
-   */
   name: string;
 }
 
@@ -35,27 +29,15 @@ export type People = Person[];
  * a test schema definition
  */
 export interface Test {
-  /**
-   * name
-   */
   name?: string;
   /**
    * A list of People
    */
   people?: People;
-  /**
-   * propertyName1
-   */
   propertyName1: boolean;
 }
 
-/**
- * Zebra
- */
 export interface Zebra {
-  /**
-   * name
-   */
   name?: string;
 }
 `;
@@ -68,21 +50,9 @@ export interface Zebra {
 
   public static personContentModel = `
 
-/**
- * Person
- */
 export interface Person {
-  /**
-   * address
-   */
   address: Address;
-  /**
-   * firstName
-   */
   firstName: string;
-  /**
-   * lastName
-   */
   lastName: string;
 }
 `;
@@ -122,34 +92,16 @@ export * from './subDir2/Employee';
 
   public static addressContent =
     AssertionCriteria.autoGenHeader +
-    `/**
- * Address
- */
-export interface Address {
-  /**
-   * Suburb
-   */
+    `export interface Address {
   Suburb: string;
-  /**
-   * addressLineNumber1
-   */
   addressLineNumber1: string;
 }
 `;
 
   public static employeeContentModel = `
 
-/**
- * Employee
- */
 export interface Employee {
-  /**
-   * personalDetails
-   */
   personalDetails: Person;
-  /**
-   * pet
-   */
   pet: Item;
 }
 `;

--- a/src/__tests__/08.allow.ts
+++ b/src/__tests__/08.allow.ts
@@ -44,25 +44,10 @@ export interface TestSchema {
    * nullable
    */
   nullName?: string | null;
-  /**
-   * blankNull
-   */
   blankNull?: string | null | '';
-  /**
-   * normalList
-   */
   normalList?: 'red' | 'green' | 'blue';
-  /**
-   * normalRequiredList
-   */
   normalRequiredList: 'red' | 'green' | 'blue';
-  /**
-   * numbers
-   */
   numbers?: 1 | 2 | 3 | 4 | 5;
-  /**
-   * nullNumber
-   */
   nullNumber?: number | null;
 }`);
 

--- a/src/__tests__/09.unknown.ts
+++ b/src/__tests__/09.unknown.ts
@@ -16,9 +16,6 @@ test('09.unknown', () => {
  * a test schema definition
  */
 export interface TestSchema {
-  /**
-   * name
-   */
   name?: string;
   /**
    * Unknown Property
@@ -39,9 +36,6 @@ export interface TestSchema {
  * a test schema definition
  */
 export interface TestSchema {
-  /**
-   * name
-   */
   name?: string;
 }`);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ export const getTypeFileNameFromSchema = (schemaFileName: string, settings: Sett
  * @param fileNamesToExport list of file names that will be added to the index.ts file
  */
 export const writeIndexFile = (settings: Settings, fileNamesToExport: string[]): void => {
-  const exportLines = fileNamesToExport.map(fileName => `export * from './${fileName}';`);
+  const exportLines = fileNamesToExport.map(fileName => `export * from './${fileName.replace(/\\/g, '/')}';`);
   const fileContent = `${settings.fileHeader}\n\n${exportLines.join('\n').concat('\n')}`;
   fs.writeFileSync(Path.join(settings.typeOutputDirectory, 'index.ts'), fileContent);
 };

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -279,7 +279,7 @@ function parseAlternatives(details: AlternativesDescribe, settings: Settings): T
 }
 
 function parseObjects(details: ObjectDescribe, settings: Settings): TypeContent | undefined {
-  let children = filterMap(Object.entries(details.keys), ([key, value]) => {
+  let children = filterMap(Object.entries(details.keys || {}), ([key, value]) => {
     const parsedSchema = parseSchema(value, settings);
     if (!parsedSchema) {
       return undefined;
@@ -298,9 +298,6 @@ function parseObjects(details: ObjectDescribe, settings: Settings): TypeContent 
     children.push(unknownProperty);
   }
 
-  if (children.length === 0) {
-    return undefined;
-  }
   if (settings.sortPropertiesByName) {
     children = children.sort((a, b) => {
       if (a.name > b.name) {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -79,9 +79,10 @@ function getIndentStr(indentLevel: number): string {
  * Get Interface jsDoc
  */
 function getDescriptionStr(name: string, description?: string, indentLevel = 0): string {
+  if (!description) return '';
   const docStr = description ? description : name;
   const lines = ['/**', ` * ${docStr}`, ' */'];
-  return lines.map(line => `${getIndentStr(indentLevel)}${line}`).join('\n');
+  return lines.map(line => `${getIndentStr(indentLevel)}${line}`).join('\n') + '\n';
 }
 
 function typeContentToTsHelper(

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -222,7 +222,7 @@ function parseBasicSchema(details: BasicDescribe, settings: Settings): TypeConte
     const allowedValues = values.map((value: unknown) => makeTypeContentChild({ content: typeof value === 'string' ? `'${value}'` : `${value}` }));
 
     if (values[0] === null) {
-      allowedValues.unshift(makeTypeContentChild({ content: joiType }));
+      allowedValues.unshift(makeTypeContentChild({ content }));
     }
     return makeTypeContentRoot({ joinOperation: 'union', children: allowedValues, name, description });
   }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -219,7 +219,7 @@ function parseBasicSchema(details: BasicDescribe, settings: Settings): TypeConte
 
   // at least one value
   if (values && values.length !== 0) {
-    const allowedValues = values.map((value: unknown) => makeTypeContentChild({ content: `${value}` }));
+    const allowedValues = values.map((value: unknown) => makeTypeContentChild({ content: typeof value === 'string' ? `'${value}'` : `${value}` }));
 
     if (values[0] === null) {
       allowedValues.unshift(makeTypeContentChild({ content: joiType }));

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -220,7 +220,9 @@ function parseBasicSchema(details: BasicDescribe, settings: Settings): TypeConte
 
   // at least one value
   if (values && values.length !== 0) {
-    const allowedValues = values.map((value: unknown) => makeTypeContentChild({ content: typeof value === 'string' ? `'${value}'` : `${value}` }));
+    const allowedValues = values.map((value: unknown) =>
+      makeTypeContentChild({ content: typeof value === 'string' ? `'${value}'` : `${value}` })
+    );
 
     if (values[0] === null) {
       allowedValues.unshift(makeTypeContentChild({ content }));
@@ -259,7 +261,7 @@ function parseStringSchema(details: StringDescribe, settings: Settings): TypeCon
 
 function parseArray(details: ArrayDescribe, settings: Settings): TypeContent | undefined {
   // TODO: handle multiple things in the items arr
-  const item = details.items ? details.items[0] : { type: 'any' } as Describe;
+  const item = details.items ? details.items[0] : ({ type: 'any' } as Describe);
   const { label: name, description } = getCommonDetails(details, settings);
 
   const child = parseSchema(item, settings);

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -131,8 +131,7 @@ function typeContentToTsHelper(
         // forcing name to be defined here, might need a runtime check but it should be set if we are here
         const descriptionStr = getDescriptionStr(child.name as string, childInfo.description, indentLevel + 1);
         const optionalStr = child.required ? '' : '?';
-        const name = /^[$A-Z_][0-9A-Z_$]*$/i.test(child.name || '') ? child.name : `"${child.name}"`;
-        return `${descriptionStr}  ${getIndentStr(indentLevel)}${name}${optionalStr}: ${childInfo.tsContent};`;
+        return `${descriptionStr}  ${getIndentStr(indentLevel)}${child.name}${optionalStr}: ${childInfo.tsContent};`;
       });
 
       const objectStr = `{\n${childrenContent.join('\n')}\n${getIndentStr(indentLevel)}}`;
@@ -153,7 +152,7 @@ export function typeContentToTs(parsedSchema: TypeContent, doExport = false): st
   const { tsContent, description } = typeContentToTsHelper(parsedSchema, doExport);
   // forcing name to be defined here, might need a runtime check but it should be set if we are here
   const descriptionStr = getDescriptionStr(parsedSchema.name as string, description);
-  return `${descriptionStr}\n${tsContent}`;
+  return `${descriptionStr}${tsContent}`;
 }
 
 // TODO: will be issues with useLabels if a nested schema has a label but is not exported on its own
@@ -287,7 +286,7 @@ function parseObjects(details: ObjectDescribe, settings: Settings): TypeContent 
     if (!parsedSchema) {
       return undefined;
     }
-    parsedSchema.name = key;
+    parsedSchema.name = /^[$A-Z_][0-9A-Z_$]*$/i.test(key || '') ? key : `"${key}"`;
     return parsedSchema as TypeContentWithName;
   });
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -126,15 +126,16 @@ function typeContentToTsHelper(
     case 'object': {
       if (!children.length && !doExport) return { tsContent: 'object', description: parsedSchema.description };
       const childrenContent = children.map(child => {
-        const childInfo = typeContentToTsHelper(child);
+        const childInfo = typeContentToTsHelper(child, false, indentLevel + 1);
         // TODO: configure indent length
         // forcing name to be defined here, might need a runtime check but it should be set if we are here
         const descriptionStr = getDescriptionStr(child.name as string, childInfo.description, indentLevel + 1);
         const optionalStr = child.required ? '' : '?';
-        return `${descriptionStr}\n  ${child.name}${optionalStr}: ${childInfo.tsContent};`;
+        const name = /^[$A-Z_][0-9A-Z_$]*$/i.test(child.name || '') ? child.name : `"${child.name}"`;
+        return `${descriptionStr}  ${getIndentStr(indentLevel)}${name}${optionalStr}: ${childInfo.tsContent};`;
       });
 
-      const objectStr = `{\n${childrenContent.join('\n')}\n}`;
+      const objectStr = `{\n${childrenContent.join('\n')}\n${getIndentStr(indentLevel)}}`;
       if (doExport) {
         return {
           tsContent: `export interface ${parsedSchema.name} ${objectStr}`,

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -124,6 +124,7 @@ function typeContentToTsHelper(
       return { tsContent: unionStr, description: parsedSchema.description };
     }
     case 'object': {
+      if (!children.length && !doExport) return { tsContent: 'object', description: parsedSchema.description };
       const childrenContent = children.map(child => {
         const childInfo = typeContentToTsHelper(child);
         // TODO: configure indent length

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -259,7 +259,7 @@ function parseStringSchema(details: StringDescribe, settings: Settings): TypeCon
 
 function parseArray(details: ArrayDescribe, settings: Settings): TypeContent | undefined {
   // TODO: handle multiple things in the items arr
-  const item = details.items[0];
+  const item = details.items ? details.items[0] : { type: 'any' } as Describe;
   const { label: name, description } = getCommonDetails(details, settings);
 
   const child = parseSchema(item, settings);

--- a/src/writeTypeFile.ts
+++ b/src/writeTypeFile.ts
@@ -60,7 +60,9 @@ export const writeTypeFile = async (
         let relativePath = Path.relative(generatedFile.typeFileLocation, customTypeLocation);
         relativePath = relativePath ? `${relativePath}` : '.';
         relativePath = relativePath.includes('..') || relativePath == '.' ? relativePath : `./${relativePath}`;
-        typeImports += `import { ${customTypeLocationDict[customTypeLocation].join(', ')} } from '${relativePath.replace(/\\/g, '/')}';\n`;
+        typeImports += `import { ${customTypeLocationDict[customTypeLocation].join(
+          ', '
+        )} } from '${relativePath.replace(/\\/g, '/')}';\n`;
       }
 
       if (typeImports) {

--- a/src/writeTypeFile.ts
+++ b/src/writeTypeFile.ts
@@ -60,7 +60,7 @@ export const writeTypeFile = async (
         let relativePath = Path.relative(generatedFile.typeFileLocation, customTypeLocation);
         relativePath = relativePath ? `${relativePath}` : '.';
         relativePath = relativePath.includes('..') || relativePath == '.' ? relativePath : `./${relativePath}`;
-        typeImports += `import { ${customTypeLocationDict[customTypeLocation].join(', ')} } from '${relativePath}';\n`;
+        typeImports += `import { ${customTypeLocationDict[customTypeLocation].join(', ')} } from '${relativePath.replace(/\\/g, '/')}';\n`;
       }
 
       if (typeImports) {


### PR DESCRIPTION
- improve indentation
- do not generate documentation, that repeats the property name
- do not throw on joi.object() and joi.array()
- generates invalid code, when properties contain dot or other symbol, which results in invalid identifier without being put in quotes
- other fixes - see the example below

Consider this example
```js
const joi = require('joi');
const {convertSchema} = require('joi-to-typescript');

// console.log(convertSchema({}, joi.object().label('emptyObject')).content); // throws

console.log(convertSchema({}, joi.object({
    // obj: joi.object(), // throws
    nested: joi.object({a: joi.object({b: joi.string()})}),
    date: joi.date().allow(null).description('This is date'),
    'x.y': joi.string(),
    // arr: joi.array(), // throws
    bit: joi.boolean().allow(0, 1, '0', '1', null)
}).label('plainObject')).content);
```

Without the fixes it will throw if the lines with //throws are uncommented.
It will generate this:
```ts
/**
 * plainObject
 */
export interface plainObject {
  /**
   * nested
   */
  nested?: {
  /**
   * a
   */
  a?: {
  /**
   * b
   */
  b?: string;
};
};
  /**
   * This is date
   */
  date?: date | null;
  /**
   * x.y
   */
  x.y?: string;
  /**
   * bit
   */
  bit?: 0 | 1 | 0 | 1 | null;
}
```

With the fixes, the generated definition is:
```ts
export interface emptyObject {

}

export interface plainObject {
  obj?: object;
  nested?: {
    a?: {
      b?: string;
    };
  };
  /**
   * This is date
   */
  date?: Date | null;
  "x.y"?: string;
  bit?: 0 | 1 | '0' | '1' | null;
  arr?: any[];
}
```