### PR TITLE
Ignore files option

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ export interface Settings {
    * Defaults to `false`
    */
   commentEverything: boolean;
+  /**
+   * List of files or folders that should be ignored from conversion. These can either be
+   * filenames (AddressSchema.ts) or filepaths postfixed with a / (addressSchemas/)
+   */
+  ignoreFiles: string[];
 }
 ```
 

--- a/src/__tests__/ignoreFiles/ignoreFiles.ts
+++ b/src/__tests__/ignoreFiles/ignoreFiles.ts
@@ -1,0 +1,69 @@
+import { rmdirSync, existsSync } from 'fs';
+
+import { convertFromDirectory } from '../../index';
+
+describe('ignore Files', () => {
+  const typeOutputDirectory = './src/__tests__/ignoreFiles/models';
+  const schemaDirectory = './src/__tests__/ignoreFiles/schemas';
+
+  beforeEach(() => {
+    rmdirSync(typeOutputDirectory, { recursive: true });
+  });
+
+  test('Ignores file names in ignoreList', async () => {
+    const ignoreFiles = ['AddressSchema.ts'];
+    const result = await convertFromDirectory({
+      schemaDirectory,
+      typeOutputDirectory,
+      ignoreFiles
+    });
+
+    expect(result).toBe(true);
+
+    expect(existsSync(`${typeOutputDirectory}/index.ts`)).toBeTruthy();
+    expect(existsSync(`${typeOutputDirectory}/One.ts`)).toBeTruthy();
+    expect(existsSync(`${typeOutputDirectory}/subDir/index.ts`)).toBeTruthy();
+    expect(existsSync(`${typeOutputDirectory}/subDir/Person.ts`)).toBeTruthy();
+    expect(existsSync(`${typeOutputDirectory}/subDir/Address.ts`)).toBeFalsy();
+    expect(existsSync(`${typeOutputDirectory}/subDir2/index.ts`)).toBeTruthy();
+    expect(existsSync(`${typeOutputDirectory}/subDir2/Employee.ts`)).toBeTruthy();
+  });
+
+  test('Ignores folder names in ignoreList', async () => {
+    const ignoreFiles = ['subDir/'];
+    const result = await convertFromDirectory({
+      schemaDirectory,
+      typeOutputDirectory,
+      ignoreFiles
+    });
+
+    expect(result).toBe(true);
+
+    expect(existsSync(`${typeOutputDirectory}/index.ts`)).toBeTruthy();
+    expect(existsSync(`${typeOutputDirectory}/One.ts`)).toBeTruthy();
+    expect(existsSync(`${typeOutputDirectory}/subDir/index.ts`)).toBeFalsy();
+    expect(existsSync(`${typeOutputDirectory}/subDir/Person.ts`)).toBeFalsy();
+    expect(existsSync(`${typeOutputDirectory}/subDir/Address.ts`)).toBeFalsy();
+    expect(existsSync(`${typeOutputDirectory}/subDir2/index.ts`)).toBeTruthy();
+    expect(existsSync(`${typeOutputDirectory}/subDir2/Employee.ts`)).toBeTruthy();
+  });
+
+  test('Ignores a file and folder in an ignore list', async () => {
+    const ignoreFiles = ['subDir2/', 'OneSchema.ts'];
+    const result = await convertFromDirectory({
+      schemaDirectory,
+      typeOutputDirectory,
+      ignoreFiles
+    });
+
+    expect(result).toBe(true);
+
+    expect(existsSync(`${typeOutputDirectory}/index.ts`)).toBeTruthy();
+    expect(existsSync(`${typeOutputDirectory}/One.ts`)).toBeFalsy();
+    expect(existsSync(`${typeOutputDirectory}/subDir/index.ts`)).toBeTruthy();
+    expect(existsSync(`${typeOutputDirectory}/subDir/Person.ts`)).toBeTruthy();
+    expect(existsSync(`${typeOutputDirectory}/subDir/Address.ts`)).toBeTruthy();
+    expect(existsSync(`${typeOutputDirectory}/subDir2/index.ts`)).toBeFalsy();
+    expect(existsSync(`${typeOutputDirectory}/subDir2/Employee.ts`)).toBeFalsy();
+  });
+});

--- a/src/__tests__/ignoreFiles/schemas/OneSchema.ts
+++ b/src/__tests__/ignoreFiles/schemas/OneSchema.ts
@@ -1,0 +1,26 @@
+import Joi from 'joi';
+import { PersonSchema } from './subDir/PersonSchema';
+
+export const ZebraSchema = Joi.object({
+  name: Joi.string()
+}).label('Zebra');
+
+export const ItemSchema = Joi.object({
+  name: Joi.string().required(),
+  maleZebra: ZebraSchema.description('Male Zebra'),
+  femaleZebra: ZebraSchema.description('Female Zebra')
+}).label('Item');
+
+export const PeopleSchema = Joi.array()
+  .items(PersonSchema)
+  .required()
+  .label('People')
+  .description('A list of People');
+
+export const TestSchema = Joi.object({
+  name: Joi.string().optional(),
+  propertyName1: Joi.boolean().required(),
+  people: PeopleSchema.optional()
+})
+  .label('Test')
+  .description('a test schema definition');

--- a/src/__tests__/ignoreFiles/schemas/subDir/AddressSchema.ts
+++ b/src/__tests__/ignoreFiles/schemas/subDir/AddressSchema.ts
@@ -1,0 +1,6 @@
+import Joi from 'joi';
+
+export const AddressSchema = Joi.object({
+  addressLineNumber1: Joi.string().required(),
+  Suburb: Joi.string().required()
+}).label('Address');

--- a/src/__tests__/ignoreFiles/schemas/subDir/PersonSchema.ts
+++ b/src/__tests__/ignoreFiles/schemas/subDir/PersonSchema.ts
@@ -1,0 +1,8 @@
+import Joi from 'joi';
+import { AddressSchema } from './AddressSchema';
+
+export const PersonSchema = Joi.object({
+  firstName: Joi.string().required(),
+  lastName: Joi.string().required(),
+  address: AddressSchema.required()
+}).label('Person');

--- a/src/__tests__/ignoreFiles/schemas/subDir2/EmployeeSchema.ts
+++ b/src/__tests__/ignoreFiles/schemas/subDir2/EmployeeSchema.ts
@@ -1,0 +1,8 @@
+import Joi from 'joi';
+import { PersonSchema } from '../subDir/PersonSchema';
+import { ItemSchema } from '../OneSchema';
+
+export const EmployeeSchema = Joi.object({
+  personalDetails: PersonSchema.required(),
+  pet: ItemSchema.required()
+}).label('Employee');

--- a/src/__tests__/subDirectories/subDirectories.ts
+++ b/src/__tests__/subDirectories/subDirectories.ts
@@ -7,7 +7,7 @@ describe('subDirectories', () => {
   const typeOutputDirectory = './src/__tests__/subDirectories/models';
   const schemaDirectory = './src/__tests__/subDirectories/schemas';
 
-  beforeAll(() => {
+  beforeEach(() => {
     rmdirSync(typeOutputDirectory, { recursive: true });
   });
 

--- a/src/convertFilesInDirectory.ts
+++ b/src/convertFilesInDirectory.ts
@@ -33,11 +33,13 @@ export const convertFilesInDirectory = async (
   const files = fs.readdirSync(appSettings.schemaDirectory);
   for (const schemaFileName of files) {
     const subDirectoryPath = Path.join(appSettings.schemaDirectory, schemaFileName);
-    if (
-      !appSettings.rootDirectoryOnly &&
-      !appSettings.rootDirectoryOnly &&
-      fs.lstatSync(subDirectoryPath).isDirectory()
-    ) {
+    if (!appSettings.rootDirectoryOnly && fs.lstatSync(subDirectoryPath).isDirectory()) {
+      if (appSettings.ignoreFiles.includes(`${schemaFileName}/`)) {
+        if (appSettings.debug) {
+          console.log(`Skipping ${subDirectoryPath} because it's in your ignore files list`);
+        }
+        continue;
+      }
       const typeOutputDirectory = appSettings.flattenTree
         ? appSettings.typeOutputDirectory
         : Path.join(appSettings.typeOutputDirectory, schemaFileName);
@@ -56,6 +58,12 @@ export const convertFilesInDirectory = async (
         fileNamesToExport = fileNamesToExport.concat(thisDirsFileNamesToExport.typeFileNames);
       }
     } else {
+      if (appSettings.ignoreFiles.includes(schemaFileName)) {
+        if (appSettings.debug) {
+          console.log(`Skipping ${schemaFileName} because it's in your ignore files list`);
+        }
+        continue;
+      }
       const exportType = await generateTypeFiles(appSettings, schemaFileName);
       if (exportType) {
         let dirTypeFileName = exportType.typeFileName;

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,9 @@ export const defaultSettings = (settings: Partial<Settings>): Settings => {
   if (appSettings.commentEverything === undefined) {
     appSettings.commentEverything = false;
   }
+  if (!appSettings.ignoreFiles) {
+    appSettings.ignoreFiles = [];
+  }
   return appSettings;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,11 @@ export interface Settings {
    * Defaults to `false`
    */
   commentEverything: boolean;
+  /**
+   * List of files or folders that should be ignored from conversion. These can either be
+   * filenames (AddressSchema.ts) or filepaths postfixed with a / (addressSchemas/)
+   */
+  ignoreFiles: string[];
 }
 
 export interface ConvertedType {


### PR DESCRIPTION
- Add an option to ignore a list of files/folders
- Files are full filenames, directories are postfixed with a `/`
- Made sure tests for sub directories are cleaned up after each run properly

I decided to not use glob pattern matching as this package currently has no dependencies which I think is worthwhile keeping, and I didn't have the brain power tonight to figure out how [Glob](https://www.npmjs.com/package/glob) works or if it was even relevant to this problem

Addresses issue #18 