### PR TITLE
Change beforeAll test to beforeEach

### DIFF
--- a/src/__tests__/none/none.ts
+++ b/src/__tests__/none/none.ts
@@ -4,7 +4,7 @@ import { convertFromDirectory } from '../../index';
 describe('empty schema directory', () => {
   const typeOutputDirectory = './src/__tests__/none/models';
 
-  beforeAll(() => {
+  beforeEach(() => {
     rmdirSync(typeOutputDirectory, { recursive: true });
   });
 


### PR DESCRIPTION
This might not be critical for this test as it currently stands, but it's important to run this cleanup before every test, not just before the test suite.

Using beforeAll caused me complications with the ignoreFiles feature because files continued exist after previous test runs had completed which skewed my file checks to have false positives