### PR TITLE
Fix local source file imports to use relative paths

### DIFF
--- a/src/analyseSchemaFile.ts
+++ b/src/analyseSchemaFile.ts
@@ -3,7 +3,7 @@ import Path from 'path';
 
 import { Settings, ConvertedType, GenerateTypeFile } from './types';
 import { getTypeFileNameFromSchema } from './index';
-import { Describe, getAllCustomTypes, parseSchema, typeContentToTs } from 'parse';
+import { Describe, getAllCustomTypes, parseSchema, typeContentToTs } from './parse';
 
 export function convertSchemaInternal(
   settings: Settings,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { writeFileSync } from 'fs';
 import { Settings, ConvertedType } from './types';
 import { convertFilesInDirectory } from './convertFilesInDirectory';
 import { writeInterfaceFile } from './writeInterfaceFile';
-import { convertSchemaInternal } from 'analyseSchemaFile';
+import { convertSchemaInternal } from './analyseSchemaFile';
 
 export { Settings };
 


### PR DESCRIPTION
When I linked `joi-to-typescript` as a dependency from the local folder, Node would try to load libraries "parse" and "analyseSchemaFile" instead of using the js file.