### PR TITLE
Escape ' and \ in generated string literals

### DIFF
--- a/src/__tests__/enum.ts
+++ b/src/__tests__/enum.ts
@@ -6,7 +6,8 @@ describe('enums tests', () => {
   test('enums using valid()', () => {
     const schema = Joi.object({
       topColour: Joi.string().valid('red', 'green', 'orange', 'blue').required(),
-      bottomColour: Joi.string().valid('red', 'green', 'orange', 'blue').required()
+      bottomColour: Joi.string().valid('red', 'green', 'orange', 'blue').required(),
+      escape: Joi.string().valid("a'b", 'c"d', "e'f'g", 'h"i"j', '\\\\').required()
     })
       .label('TestSchema')
       .description('a test schema definition');
@@ -19,6 +20,7 @@ describe('enums tests', () => {
 export interface TestSchema {
   topColour: 'red' | 'green' | 'orange' | 'blue';
   bottomColour: 'red' | 'green' | 'orange' | 'blue';
+  escape: 'a\\'b' | 'c"d' | 'e\\'f\\'g' | 'h"i"j' | '\\\\\\\\';
 }`);
   });
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,5 +1,5 @@
 import Joi from 'joi';
-import { filterMap } from './utils';
+import { filterMap, toStringLiteral } from './utils';
 import { TypeContent, makeTypeContentRoot, makeTypeContentChild, Settings, JsDoc } from './types';
 
 // see __tests__/joiTypes.ts for more information
@@ -249,7 +249,7 @@ function parseBasicSchema(details: BasicDescribe, settings: Settings): TypeConte
   // at least one value
   if (values && values.length !== 0) {
     const allowedValues = values.map((value: unknown) =>
-      makeTypeContentChild({ content: typeof value === 'string' ? `'${value}'` : `${value}` })
+      makeTypeContentChild({ content: typeof value === 'string' ? toStringLiteral(value) : `${value}` })
     );
 
     if (values[0] === null) {
@@ -274,7 +274,7 @@ function parseStringSchema(details: StringDescribe, settings: Settings): TypeCon
       const allowedValues = values.map(value =>
         stringAllowValues.includes(value) && value !== ''
           ? makeTypeContentChild({ content: `${value}` })
-          : makeTypeContentChild({ content: `'${value}'` })
+          : makeTypeContentChild({ content: toStringLiteral(value) })
       );
 
       if (values.filter(value => stringAllowValues.includes(value)).length == values.length) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,3 +14,11 @@ export function filterMap<T, K>(list: T[], mapper: (t: T) => K | undefined): K[]
     return res;
   }, []);
 }
+
+/**
+ * Escape value so that it can be go into single quoted string literal.
+ * @param value
+ */
+export function toStringLiteral(value: string): string {
+  return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}


### PR DESCRIPTION
During generating types we encountered a string value that contained a single quote character. Since it was not escaped, the resulting TS file could not compile.
This PR adds `'` and `\` escaping, keeping string literals with single quotes as before.