### PR TITLE
Map output file and type name to custom string

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,16 @@ export interface Settings {
    * @default '  ' (two spaces)
    */
   indentationChacters: string;
+  /**
+   * Can be used to customize the name of the generated file.
+   * @default (fileName: string) => fileName
+   */
+  readonly mapTypeFileName: (fileName: string) => string;
+  /**
+   * Can be used to customize resulting type name.
+   * @default (name: string) => name
+   */
+  readonly mapTypeName: (name: string) => string;
 }
 ```
 

--- a/src/analyseSchemaFile.ts
+++ b/src/analyseSchemaFile.ts
@@ -11,10 +11,15 @@ export function convertSchemaInternal(
   exportedName?: string
 ): ConvertedType | undefined {
   const details = joi.describe() as Describe;
-  const name = details?.flags?.label || exportedName;
+  const defaultName = details?.flags?.label || exportedName;
 
-  if (!name) {
+  if (!defaultName) {
     throw new Error(`At least one "object" does not have a .label(). Details: ${JSON.stringify(details)}`);
+  }
+
+  const name = settings.mapTypeName(defaultName);
+  if (!name) {
+    throw new Error(`Resulting type name cannot be empty. Default name was: ${defaultName}`);
   }
 
   if (settings.debug && name.toLowerCase().endsWith('schema')) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,9 @@ function defaultSettings(settings: Partial<Settings>): Settings {
       sortPropertiesByName: true,
       commentEverything: false,
       ignoreFiles: [],
-      indentationChacters: '  '
+      indentationChacters: '  ',
+      mapTypeFileName: (fileName: string) => fileName,
+      mapTypeName: (name: string) => name
     },
     settings
   ) as Settings;
@@ -46,9 +48,11 @@ export function convertSchema(
 }
 
 export function getTypeFileNameFromSchema(schemaFileName: string, settings: Settings): string {
-  return schemaFileName.endsWith(`${settings.schemaFileSuffix}.ts`)
-    ? schemaFileName.substring(0, schemaFileName.length - `${settings.schemaFileSuffix}.ts`.length)
-    : schemaFileName.replace('.ts', '');
+  return settings.mapTypeFileName(
+    schemaFileName.endsWith(`${settings.schemaFileSuffix}.ts`)
+      ? schemaFileName.substring(0, schemaFileName.length - `${settings.schemaFileSuffix}.ts`.length)
+      : schemaFileName.replace('.ts', '')
+  );
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,16 @@ export interface Settings {
    * @default '  ' (two spaces)
    */
   readonly indentationChacters: string;
+  /**
+   * Can be used to customize the name of the generated file.
+   * @default (fileName: string) => fileName
+   */
+  readonly mapTypeFileName: (fileName: string) => string;
+  /**
+   * Can be used to customize resulting type name.
+   * @default (name: string) => name
+   */
+  readonly mapTypeName: (name: string) => string;
 }
 
 export interface ConvertedType {


### PR DESCRIPTION
Adding possibility to map types and file names with a mapping function to allow different naming schemas.

E.g., by us, we uppercase the first letter of the exported variable name and add `Types` suffix to the filename.