### PR TITLE
Attempt to handle unsupported Joi types rather than omitting them

### DIFF
--- a/src/__tests__/joiExtensions/joiExtensions.ts
+++ b/src/__tests__/joiExtensions/joiExtensions.ts
@@ -1,0 +1,53 @@
+import Joi from 'joi';
+import { convertSchema } from '../..';
+
+// Add a couple of extensions to Joi, one without specifying the base type
+const ExtendedJoi = Joi.extend(joi => {
+  const ext: Joi.Extension = {
+    type: 'objectId',
+    base: joi.string().meta({ baseType: 'string' })
+  };
+  return ext;
+}).extend((joi: any) => {
+  const ext: Joi.Extension = {
+    type: 'dollars',
+    base: joi.number()
+  };
+  return ext;
+});
+
+describe('Joi Extensions', () => {
+  test('An extended type with baseType set in metadata', () => {
+    const schema = Joi.object({
+      doStuff: ExtendedJoi.objectId()
+    }).meta({ className: 'Test' });
+
+    const result = convertSchema({ debug: true }, schema);
+    expect(result).not.toBeUndefined;
+    // prettier-ignore
+    expect(result?.content).toBe(
+       [
+         'export interface Test {',
+         '  doStuff?: string;',
+         '}'
+       ].join('\n')
+     );
+  });
+
+  test('An extended type with baseType not set in metadata', () => {
+    const schema = Joi.object({
+      doStuff: ExtendedJoi.dollars()
+    }).meta({ className: 'Test' });
+
+    const result = convertSchema({ debug: true }, schema);
+    expect(result).not.toBeUndefined;
+    // prettier-ignore
+    expect(result?.content).toBe(
+       [
+         'export interface Test {',
+         '  doStuff?: unknown;',
+         '}'
+       ].join('\n')
+     );
+  });
+});

--- a/src/__tests__/joiTypes.ts
+++ b/src/__tests__/joiTypes.ts
@@ -32,7 +32,6 @@ describe('`Joi.types()`', () => {
   });
 
   test('Joi.function()', () => {
-    const consoleSpy = jest.spyOn(console, 'debug');
     const schema = Joi.object({
       doStuff: Joi.function(),
       moreThings: Joi.func()
@@ -40,46 +39,67 @@ describe('`Joi.types()`', () => {
 
     const result = convertSchema({ debug: true }, schema);
     expect(result).not.toBeUndefined;
-    expect(result?.content).toBe(`export interface Test {}`);
-    expect(consoleSpy).toHaveBeenCalledWith('unsupported type: function');
+    expect(result?.content).toBe(
+      [
+        'export interface Test {',
+        '  doStuff?: (...args: any[]) => any;',
+        '  moreThings?: (...args: any[]) => any;',
+        '}'
+      ].join('\n')
+    );
   });
 
   // TODO: It might be possible to support link
   // I guess this would find the referenced schema and get its type
   test('Joi.link()', () => {
-    const consoleSpy = jest.spyOn(console, 'debug');
     const schema = Joi.object({
       doStuff: Joi.link()
     }).meta({ className: 'Test' });
 
     const result = convertSchema({ debug: true }, schema);
     expect(result).not.toBeUndefined;
-    expect(result?.content).toBe(`export interface Test {}`);
-    expect(consoleSpy).toHaveBeenCalledWith('unsupported type: link');
+    // prettier-ignore
+    expect(result?.content).toBe(
+      [
+        'export interface Test {',
+        '  doStuff?: unknown;',
+        '}'
+      ].join('\n')
+    );
   });
 
   test('Joi.symbol()', () => {
-    const consoleSpy = jest.spyOn(console, 'debug');
     const schema = Joi.object({
       doStuff: Joi.symbol()
     }).meta({ className: 'Test' });
 
     const result = convertSchema({ debug: true }, schema);
     expect(result).not.toBeUndefined;
-    expect(result?.content).toBe(`export interface Test {}`);
-    expect(consoleSpy).toHaveBeenCalledWith('unsupported type: symbol');
+    // prettier-ignore
+    expect(result?.content).toBe(
+      [
+        'export interface Test {',
+        '  doStuff?: symbol;',
+        '}'
+      ].join('\n')
+    );
   });
 
   // TODO: Support Binary
   test('Joi.binary()', () => {
-    const consoleSpy = jest.spyOn(console, 'debug');
     const schema = Joi.object({
       doStuff: Joi.binary()
     }).meta({ className: 'Test' });
 
     const result = convertSchema({ debug: true }, schema);
     expect(result).not.toBeUndefined;
-    expect(result?.content).toBe(`export interface Test {}`);
-    expect(consoleSpy).toHaveBeenCalledWith('unsupported type: binary');
+    // prettier-ignore
+    expect(result?.content).toBe(
+      [
+        'export interface Test {',
+        '  doStuff?: Buffer;',
+        '}'
+      ].join('\n')
+    );
   });
 });

--- a/src/joiUtils.ts
+++ b/src/joiUtils.ts
@@ -2,6 +2,20 @@ import { Settings } from '.';
 import { Describe } from './joiDescribeTypes';
 
 /**
+ * Fetch the metadata values for a given field. Note that it is possible to have
+ * more than one metadata record for a given field hence it is possible to get
+ * back a list of values.
+ *
+ * @param field - the name of the metadata field to fetch
+ * @param details - the schema details
+ * @returns the values for the given field
+ */
+export function getMetadataFromDetails(field: string, details: Describe): any[] {
+  const metas: any[] = details?.metas ?? [];
+  return metas.filter(entry => entry[field]).map(entry => entry[field]);
+}
+
+/**
  * Get the interface name from the Joi
  * @returns a string if it can find one
  */
@@ -10,11 +24,11 @@ export function getInterfaceOrTypeName(settings: Settings, details: Describe): s
     return details?.flags?.label?.replace(/\s/g, '');
   } else {
     if (details?.metas && details.metas.length > 0) {
-      const classNames = details.metas.filter(meta => meta.className);
-      if (classNames.length !== 0){
+      const classNames: string[] = getMetadataFromDetails('className', details);
+      if (classNames.length !== 0) {
         // If Joi.concat() has been used then there may be multiple
         // get the last one as that should be the correct one
-        const className = classNames[classNames.length - 1].className;
+        const className = classNames.pop();
         return className?.replace(/\s/g, '');
       }
     }


### PR DESCRIPTION
- currently unsupported Joi types are dropped from the interface
  generation which also includes an Joi extensions added
- rather than doing that, attempt to workout a suitable TypeScript
  type to use for them in the interface generation
- for Joi extensions, it is possible to add the base type in the
  metadata in the same way that joi-to-swagger recommends:

  const ExtendedJoi = Joi.extend(joi => {
    const ext: Joi.Extension = {
      type: 'objectId',
      base: joi.string().meta({ baseType: 'string' })
    };
    return ext;
  });

- use 'unknown' if no suitable type can be deduced