### PR TITLE
Accept Joi schemas and strings in unknown type assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install joi-to-typescript --save-dev
 ```
 
 - This has been built for `"joi": "^17"` and will not work for older versions
-- Minimum node version 12 as Joi requries node 12
+- Minimum node version 12 as Joi requires node 12
 
 ## Suggested Usage
 
@@ -117,8 +117,8 @@ export interface Wallet {
 
 - `export const PersonSchema` schema must be exported
 - `export const PersonSchema` includes a suffix of Schema so the schema and interface are not confused when using `import` statements (recommended not required)
-- `.meta({className:'Person'});` Sets `interface` name using TypeScript conventions (TitleCase Interface name, camlCase property name)
-- `.meta({unknownType:'number'});` assert unknown type to `number`
+- `.meta({ className: 'Person' });` Sets `interface` name using TypeScript conventions (TitleCase Interface name, camelCase property name)
+- `.meta({ unknownType: 'number' });` assert unknown type to `number`
 
 #### Upgrade Notice
 
@@ -217,19 +217,26 @@ export interface Settings {
 
 ## Joi Features Supported
 
-- .meta({className:'InterfaceName'}) - interface Name and in jsDoc
-- .description('What this interface is for') - jsdoc
-- .valid(['red', 'green', 'blue']) - enumerations
-- .optional() - optional properties `?`
-- .required() - required properties
-- .array(), .object(), .string(), .number(), .boolean() - standard Joi schemas
-- .alternatives()
-- .allow('') - will be ignored on a string
-- .allow(null) - will add as an optional type eg `string | null`
-- .unknown(true) - will add a property `[x: string]: unknown;`, assert `unknown` to some type with `.meta({ unknownType: 'some-type' })`
-- .example() - jsdoc
-- .cast() - currently will honor casting to string and number types, map and set to be added later
-  Any many others
+- `.meta({className:'InterfaceName'})` - interface Name and in jsDoc
+- `.description('What this interface is for')` - jsdoc
+- `.valid(['red', 'green', 'blue'])` - enumerations
+- `.optional()` - optional properties `?`
+- `.required()` - required properties
+- `.array()`, `.object()`, `.string()`, `.number()`, `.boolean()` - standard Joi schemas
+- `.alternatives()`
+- `.allow('')` - will be ignored on a string
+- `.allow(null)` - will add as an optional type eg `string | null`
+- `.unknown(true)` - will add a property `[x: string]: unknown;` to the interface
+  - Assert `unknown` to some type with a stringified type or a Joi schema, e.g.:
+  ```typescript
+    .meta({ unknownType: 'some-type' })
+  ```
+  ```typescript
+    .meta({ unknownType: Joi.object({ id: Joi.string() }) })`
+  ```
+- `.example()` - jsdoc
+- `.cast()` - currently will honor casting to string and number types, map and set to be added later
+- And many others
 
 ## Contributing
 
@@ -239,7 +246,7 @@ export interface Settings {
 
 ### Recommended Development Environment
 
-Recommended Editor is VS Code, this project is setup with VSCode settings in the `./.vscode` directory to keep development consistant.
+Recommended Editor is VS Code, this project is setup with VSCode settings in the `./.vscode` directory to keep development consistent.
 
 Best developed on macOS, Linux, or on Windows via WSL.
 Node 12, 14, or 16

--- a/src/__tests__/unknown.ts
+++ b/src/__tests__/unknown.ts
@@ -65,7 +65,7 @@ export interface TestSchema {
 }`);
   });
 
-  test('`pattern(Joi.string(), Joi.number)`', () => {
+  test('`pattern(Joi.string(), Joi.number())`', () => {
     const schema = Joi.object({
       name: Joi.string()
     })
@@ -84,6 +84,51 @@ export interface TestSchema {
    * Number Property
    */
   [x: string]: number;
+}`);
+  });
+
+  test('`unknown(true).meta({ unknownType: Joi.AnySchema() })`', () => {
+    const schema = Joi.object({})
+      .unknown(true)
+      .meta({
+        className: 'TestSchema',
+        unknownType: Joi.array().items(
+          Joi.object({
+            id: Joi.string().required()
+          })
+        )
+      })
+      .description('a test schema definition');
+
+    const result = convertSchema({}, schema);
+    expect(result).not.toBeUndefined;
+    expect(result?.content).toBe(`/**
+ * a test schema definition
+ */
+export interface TestSchema {
+  [x: string]: {
+    id: string;
+  }[];
+}`);
+  });
+
+  test('`pattern(Joi.string(), Joi.AnySchema())`', () => {
+    const unknownTypeSchema = Joi.array().items(Joi.object({ id: Joi.string().required() }));
+
+    const schema = Joi.object({})
+      .pattern(Joi.string(), unknownTypeSchema)
+      .meta({ className: 'TestSchema', unknownType: unknownTypeSchema })
+      .description('a test schema definition');
+
+    const result = convertSchema({}, schema);
+    expect(result).not.toBeUndefined;
+    expect(result?.content).toBe(`/**
+ * a test schema definition
+ */
+export interface TestSchema {
+  [x: string]: {
+    id: string;
+  }[];
 }`);
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { Describe } from 'joiDescribeTypes';
+
 /**
  * Applies the mapper over each element in the list.
  * If the mapper returns undefined it will not show up in the result
@@ -21,4 +23,16 @@ export function filterMap<T, K>(list: T[], mapper: (t: T) => K | undefined): K[]
  */
 export function toStringLiteral(value: string): string {
   return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+export function isDescribe(x: unknown): x is Describe {
+  if (!x) {
+    return false
+  }
+
+  if ((x as Describe).type) {
+    return true
+  }
+
+  return false
 }


### PR DESCRIPTION
As a follow-up to https://github.com/mrjono1/joi-to-typescript/issues/168, I've extended the unknown type assertion to accept Joi schemas and updated and added a few fixes to the README.

So now, complex types will be properly reproduced when creating complex `Record`s and if `.pattern(Joi.string(), ...)` is used, the Joi validation will still be taken into account, but the generated type will be more accurate.