### PR TITLE
Add CLI interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,49 @@ npm install joi-to-typescript --save-dev
 ## Suggested Usage
 
 1. Create a Schemas Folder eg. `src/schemas`
-1. Create a interfaces Folder eg. `src/interfaces`
-1. Create Joi Schemas in the Schemas folder with a file name suffix of Schemas eg. `AddressSchema.ts`
+2. Create a interfaces Folder eg. `src/interfaces`
+3. Create Joi Schemas in the Schemas folder with a file name suffix of Schemas eg. `AddressSchema.ts`
    - The file name suffix ensures that type file and schema file imports are not confusing
+4. Call `joi-to-typescript` programmatically via a wrapper script or directly from CLI
 
+### Programmatic usage
+
+```
+import { convertFromDirectory } from 'joi-to-typescript';
+
+convertFromDirectory({
+  schemaDirectory: './src/schemas',
+  typeOutputDirectory: './src/interfaces',
+  debug: true
+});
+```
+
+### CLI usage
+
+The `joi-to-typescript` package defines a binary which can be called either using `npx` or by installing the package
+globally using `npm install -g joi-to-typescript`:
+
+```
+joi-to-typescript [options] <schema directory> <output directory>
+```
+
+Example:
+```
+$ npx joi-to-typescript --debug ./src/schemas ./src/interfaces
+```
+
+Supported options:
+
+```
+  --debug       Print debug information
+  --sort        Order of properties in generated interfaces. Allowed values: name. Default: properties are sorted in the order they appear in the schema.
+  --label       Use .label('InterfaceName') instead of .meta({className:'InterfaceName'}) for interface names. Default: false
+  --required    Make all interface properties required by default, even if the schema does not. Default: false
+  --suffix      Schema suffix to strip from interface names. Default: "schema"
+  --flatten     Will not output to subDirectories in output/interface directory. It will flatten the structure. Default: false
+  --rootOnly    Will only read the files in the root directory of the input/schema directory. Will not parse through sub-directories. Default: false
+  --indent      Indentation characters. Default: "  " (two spaces)
+```
 ## Example
 
 #### Example Project
@@ -124,7 +163,7 @@ export interface Wallet {
 
 - Version 1 used `.label('Person')` as the way to define the `interface` name, to use this option set `{ useLabelAsInterfaceName: true }`
 
-#### Example Call
+#### Example Call via wrapper script
 
 ```typescript
 import { convertFromDirectory } from 'joi-to-typescript';
@@ -141,6 +180,11 @@ const resultingInterface = convertSchema({}, JobSchema);
 resultingInterface?.content = // the interface as a string
 ```
 
+#### Example call via CLI
+
+```
+$ npx joi-to-typescript --debug ./src/schemas ./src/interfaces
+```
 ## Settings
 
 ```typescript

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Convert Joi Schemas to TypeScript interfaces",
   "version": "2.4.0",
   "author": "Jono Clarnette",
+  "bin": "dist/bin/cli.js",
   "keywords": [
     "joi",
     "ts",
@@ -29,6 +30,7 @@
     "pub": "tsc && yarn publish"
   },
   "dependencies": {
+    "@pawelgalazka/cli": "^2.0.3",
     "joi": "^17.4.0"
   },
   "devDependencies": {
@@ -42,6 +44,7 @@
     "jest": "^27.1.0",
     "prettier": "^2.2.1",
     "ts-jest": "^27.0.5",
+    "ts-node": "^10.4.0",
     "typescript": "4.5.4"
   },
   "jest": {

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env ts-node
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// noinspection ExceptionCaughtLocallyJS
+
+import {resolve} from 'path';
+import {cli, CommandFunction, help} from '@pawelgalazka/cli'
+import {convertFromDirectory} from '..';
+
+const joi2ts: CommandFunction = async (options, schemaDirectory, typeOutputDirectory = '.') => {
+  try {
+    if (!schemaDirectory) {
+      throw new Error('Missing schema directory');
+    }
+
+    if (typeof options.sort === 'string' && !['name'].includes(options.sort)) {
+      throw new Error(`Invalid sort value ${options.sort}`);
+    }
+    await convertFromDirectory({
+      schemaDirectory,
+      typeOutputDirectory,
+      debug: !!options.debug,
+      sortPropertiesByName: options.sort === 'name',
+      useLabelAsInterfaceName: !!options.label,
+      defaultToRequired: !!options.required,
+      flattenTree: !!options.flatten,
+      rootDirectoryOnly: !!options.rootOnly,
+      ...typeof options.suffix === 'string' && {schemaFileSuffix: options.suffix},
+      ...typeof options.indent === 'string' && {indentationChacters: options.indent}
+    });
+    console.log(`Wrote types generated from JOI schemas to ${resolve(typeOutputDirectory)}`);
+  } catch (err: any) {
+    console.error(options.debug ? err : `Error: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+help(joi2ts, 'Create TypeScript type definitions from JOI schemas', {
+  options: {
+    debug: 'Print debug information',
+    sort: 'Order of properties in generated interfaces. Allowed values: name. Default: properties are sorted in the order they appear in the schema.',
+    label: 'Use .label(\'InterfaceName\') instead of .meta({className:\'InterfaceName\'}) for interface names. Default: false',
+    required: 'Make all interface properties required by default, even if the schema does not. Default: false',
+    suffix: 'Schema suffix to strip from interface names. Default: "schema"',
+    flatten: 'Will not output to subDirectories in output/interface directory. It will flatten the structure. Default: false',
+    rootOnly: 'Will only read the files in the root directory of the input/schema directory. Will not parse through sub-directories. Default: false',
+    indent: 'Indentation characters. Default: "  " (two spaces)'
+  },
+  params: ['schemaDir', 'outputDir']
+});
+
+cli(joi2ts);

--- a/yarn.lock
+++ b/yarn.lock
@@ -309,6 +309,18 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@cspotcode/source-map-consumer@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
+  integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
+
+"@cspotcode/source-map-support@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz#4789840aa859e46d2f3173727ab707c66bf344f5"
+  integrity sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==
+  dependencies:
+    "@cspotcode/source-map-consumer" "0.8.0"
+
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.3.tgz#9e42981ef035beb3dd49add17acb96e8ff6f394c"
@@ -556,6 +568,26 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@pawelgalazka/cli-args@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@pawelgalazka/cli-args/-/cli-args-1.1.3.tgz#7880b7e4213df516f79b200438290f3966a22428"
+  integrity sha512-snkj9nX11F/2+7t/aQUbGC4iYMMZ2BQMoSsJ0IUUimzkOM9jb12QFAGubsOo9TibmfTN/g0DJ+ciOgXB/YEClQ==
+
+"@pawelgalazka/cli@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@pawelgalazka/cli/-/cli-2.0.3.tgz#69ccfb43c69457c2c7d040a95e163ec207663186"
+  integrity sha512-PjR8WGDfd8KLFdRS0ceZC/V99xCMN+z6MVThoaqODEOrgwSyP1qA1nVc8JXOI5cxGQ5OBvSDikrvulXYnzgIjg==
+  dependencies:
+    "@pawelgalazka/cli-args" "1.1.3"
+    "@pawelgalazka/middleware" "1.0.0"
+    chalk "2.4.2"
+    lodash "4.17.15"
+
+"@pawelgalazka/middleware@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@pawelgalazka/middleware/-/middleware-1.0.0.tgz#b772fecd221903fb41a7be799ab092c72ad24b68"
+  integrity sha512-BHE0ZFTDhfrAWzeoeUkhKXCjh0NFcd7dYJJiekW6sp3xbhaWTVBoaJbyZthWJEeow4FHJInjeEIBwbkGKqZzRg==
+
 "@sideway/address@^4.1.0":
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.2.tgz#811b84333a335739d3969cfc434736268170cad1"
@@ -591,6 +623,26 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+
+"@tsconfig/node10@^1.0.7":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
+  integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
+  integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
+  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
+  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
   version "7.1.16"
@@ -789,6 +841,11 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^7.1.1, acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
@@ -798,6 +855,11 @@ acorn@^8.2.4:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.6.0.tgz#e3692ba0eb1a0c83eaa4f37f5fa7368dd7142895"
   integrity sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==
+
+acorn@^8.4.1:
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
+  integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
 
 agent-base@6:
   version "6.0.2"
@@ -869,6 +931,11 @@ anymatch@^3.0.3:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -1028,7 +1095,7 @@ caniuse-lite@^1.0.30001280:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz#38c781ee0a90ccfe1fe7fefd00e43f5ffdcb96fd"
   integrity sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==
 
-chalk@^2.0.0:
+chalk@2.4.2, chalk@^2.0.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -1122,6 +1189,11 @@ convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   dependencies:
     safe-buffer "~5.1.1"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -1198,6 +1270,11 @@ diff-sequences@^27.4.0:
   version "27.4.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.4.0.tgz#d783920ad8d06ec718a060d00196dfef25b132a5"
   integrity sha512-YqiQzkrsmHMH5uuh8OdQFU9/ZpADnwzml8z0O5HvRNda+5UZsaX/xN+AAxfR2hWq1Y7HZnAzO9J5lJXOuDz2Ww==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -2367,6 +2444,11 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
+lodash@4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
@@ -2386,7 +2468,7 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@1.x:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -2992,6 +3074,24 @@ ts-jest@^27.0.5:
     semver "7.x"
     yargs-parser "20.x"
 
+ts-node@^10.4.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.4.0.tgz#680f88945885f4e6cf450e7f0d6223dd404895f7"
+  integrity sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==
+  dependencies:
+    "@cspotcode/source-map-support" "0.7.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    yn "3.1.1"
+
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -3201,3 +3301,8 @@ yargs@^16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
This adds a CLI interface so that joi-to-typescript can be invoked as a binary.
Example:

    $ joi-to-typescript src/schemas gen --sort=name --debug

The binary requires that ts-node is installed globally.

Fixes #183.