### PR TITLE
Extra options for working with fields containing defaults

### DIFF
--- a/src/__tests__/defaults/defaults.ts
+++ b/src/__tests__/defaults/defaults.ts
@@ -1,0 +1,99 @@
+import Joi from 'joi'
+
+import {
+  convertSchema
+} from '../../index'
+
+describe('Test behaviour for optional fields with supplied defaults', function () {
+  // A junk schema which tests a combination of values and defaults
+  const schema = Joi.object({
+    str: Joi.string().default('Test'),
+    num: Joi.number().default(1),
+    bool: Joi.boolean().default(true),
+    arr: Joi.array().items(Joi.number()).default([1, 2, 3]),
+    arr2: Joi.array().items(Joi.string()).default(['X', 'Y', 'Z']),
+    alt: Joi.alternatives().try(Joi.string(), Joi.number()).default('Test'),
+    obj: Joi.object({
+      val: Joi.string()
+    }).default({
+      val: 'Test'
+    }),
+    alt2: Joi.alternatives().try(Joi.string(), Joi.number(), Joi.object({ val: Joi.boolean().default(true) })).default({ val: false })
+  })
+
+  it('Test defaults as optional and excluded from types', function () {
+    const converted = convertSchema({ supplyDefaultsInType: false, treatDefaultedOptionalAsRequired: false }, schema, 'Test')
+    expect(converted).toBeDefined()
+    expect(converted?.content).toEqual(`export interface Test {
+  alt?: string | number;
+  alt2?: string | number | {
+    val?: boolean;
+  };
+  arr?: number[];
+  arr2?: string[];
+  bool?: boolean;
+  num?: number;
+  obj?: {
+    val?: string;
+  };
+  str?: string;
+}`)
+  })
+  it('Test defaults as required and excluded from types', function () {
+    const converted = convertSchema({ supplyDefaultsInType: false, treatDefaultedOptionalAsRequired: true }, schema, 'Test')
+
+    // Should be considered a valid schema
+    expect(converted).toBeDefined()
+
+    expect(converted?.content).toEqual(`export interface Test {
+  alt: string | number;
+  alt2: string | number | {
+    val: boolean;
+  };
+  arr: number[];
+  arr2: string[];
+  bool: boolean;
+  num: number;
+  obj: {
+    val?: string;
+  };
+  str: string;
+}`)
+  })
+  it('Test defaults as optional and included in types', function () {
+    const converted = convertSchema({ supplyDefaultsInType: true, treatDefaultedOptionalAsRequired: false }, schema, 'Test')
+    expect(converted).toBeDefined()
+    expect(converted?.content).toEqual(`export interface Test {
+  alt?: "Test" | string | number;
+  alt2?: {"val":false} | string | number | {
+    val?: true | boolean;
+  };
+  arr?: [1,2,3] | number;
+  arr2?: ["X","Y","Z"] | string;
+  bool?: true | boolean;
+  num?: 1 | number;
+  obj?: {"val":"Test"} | {
+    val?: string;
+  };
+  str?: "Test" | string;
+}`)
+  })
+  it('Test defaults as required and included in types', function () {
+    const converted = convertSchema({ supplyDefaultsInType: true, treatDefaultedOptionalAsRequired: true }, schema, 'Test')
+    expect(converted).toBeDefined()
+    expect(converted?.content).toEqual(`export interface Test {
+  alt: "Test" | string | number;
+  alt2: {"val":false} | string | number | {
+    val: true | boolean;
+  };
+  arr: [1,2,3] | number;
+  arr2: ["X","Y","Z"] | string;
+  bool: true | boolean;
+  num: 1 | number;
+  obj: {"val":"Test"} | {
+    val?: string;
+  };
+  str: "Test" | string;
+}`)
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,8 @@ function defaultSettings(settings: Partial<Settings>): Settings {
       ignoreFiles: [],
       indentationChacters: '  ',
       honorCastTo: [],
-      enforceDefaultsOnOptional: false
+      treatDefaultedOptionalAsRequired: false,
+      supplyDefaultsInType: false
     },
     settings
   ) as Settings;

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,8 @@ function defaultSettings(settings: Partial<Settings>): Settings {
       commentEverything: false,
       ignoreFiles: [],
       indentationChacters: '  ',
-      honorCastTo: []
+      honorCastTo: [],
+      enforceDefaultsOnOptional: false
     },
     settings
   ) as Settings;

--- a/src/joiDescribeTypes.ts
+++ b/src/joiDescribeTypes.ts
@@ -26,6 +26,10 @@ export interface BaseDescribe extends Joi.Description {
      */
     presence?: 'optional' | 'required';
     /**
+     * Default object value
+     */
+    default?: unknown;
+    /**
      * https://joi.dev/api/#objectunknownallow
      */
     unknown?: boolean;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -28,10 +28,10 @@ function getCommonDetails(
   const example = details.examples?.[0];
 
   let required;
-  if (presence === 'optional') {
-    required = false;
-  } else if (presence === 'required') {
+  if (presence === 'required' || (settings.treatDefaultedOptionalAsRequired && value !== undefined)) {
     required = true;
+  } else if (presence === 'optional') {
+    required = false;
   } else {
     required = settings.defaultToRequired;
   }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -21,10 +21,11 @@ const validCastTo = ['string', 'number'];
 function getCommonDetails(
   details: Describe,
   settings: Settings
-): { interfaceOrTypeName?: string; jsDoc: JsDoc; required: boolean } {
+): { interfaceOrTypeName?: string; jsDoc: JsDoc; required: boolean, value?: unknown } {
   const interfaceOrTypeName = getInterfaceOrTypeName(settings, details);
   const description = details.flags?.description;
   const presence = details.flags?.presence;
+  const value = details.flags?.default;
   const example = details.examples?.[0];
 
   let required;
@@ -35,7 +36,7 @@ function getCommonDetails(
   } else {
     required = settings.defaultToRequired;
   }
-  return { interfaceOrTypeName, jsDoc: { description, example }, required };
+  return { interfaceOrTypeName, jsDoc: { description, example }, required, value };
 }
 
 export function getAllCustomTypes(parsedSchema: TypeContent): string[] {
@@ -77,6 +78,18 @@ function getDescriptionStr(settings: Settings, name: string, jsDoc?: JsDoc, inde
   return lines.map(line => `${getIndentStr(settings, indentLevel)}${line}`).join('\n') + '\n';
 }
 
+const wrapValue = (value: any): string | object | boolean | number => {
+  if (typeof value === 'string') {
+    return `"${value}"`
+  } else if (Array.isArray(value)) {
+    return `[${value.map((av) => wrapValue(av))}]`
+  } else if (typeof value === 'object') {
+    return JSON.stringify(value)
+  } else {
+    return value
+  }
+}
+
 function typeContentToTsHelper(
   settings: Settings,
   parsedSchema: TypeContent,
@@ -85,7 +98,11 @@ function typeContentToTsHelper(
 ): { tsContent: string; jsDoc?: JsDoc } {
   if (!parsedSchema.__isRoot) {
     return {
-      tsContent: parsedSchema.content,
+      tsContent: settings.supplyDefaultsInType
+        ? parsedSchema.value !== undefined
+          ? `${wrapValue(parsedSchema.value)} | ${parsedSchema.content}`
+          : parsedSchema.content
+        : parsedSchema.content,
       jsDoc: parsedSchema.jsDoc
     };
   }
@@ -106,7 +123,11 @@ function typeContentToTsHelper(
         // TODO: might need a better way to add the parens for union
         content = `(${content})`;
       }
-      const arrayStr = `${content}[]`;
+      const arrayStr = settings.supplyDefaultsInType
+        ? parsedSchema.value !== undefined
+          ? `${wrapValue(parsedSchema.value)} | ${content}`
+          : `${content}[]`
+        : `${content}[]`;
       if (doExport) {
         return {
           tsContent: `export type ${parsedSchema.interfaceOrTypeName} = ${arrayStr};`,
@@ -118,13 +139,18 @@ function typeContentToTsHelper(
     case 'union': {
       const childrenContent = children.map(child => typeContentToTsHelper(settings, child, indentLevel).tsContent);
       const unionStr = childrenContent.join(' | ');
+      const finalStr = settings.supplyDefaultsInType
+        ? parsedSchema.value !== undefined
+          ? `${wrapValue(parsedSchema.value)} | ${unionStr}`
+          : unionStr
+        : unionStr
       if (doExport) {
         return {
-          tsContent: `export type ${parsedSchema.interfaceOrTypeName} = ${unionStr};`,
+          tsContent: `export type ${parsedSchema.interfaceOrTypeName} = ${finalStr};`,
           jsDoc: parsedSchema.jsDoc
         };
       }
-      return { tsContent: unionStr, jsDoc: parsedSchema.jsDoc };
+      return { tsContent: finalStr, jsDoc: parsedSchema.jsDoc };
     }
     case 'object': {
       if (!children.length && !doExport) {
@@ -150,6 +176,10 @@ function typeContentToTsHelper(
           return `${descriptionStr}${indentString}${child.interfaceOrTypeName}${optionalStr}: ${childInfo.tsContent};`;
         });
         objectStr = `{\n${childrenContent.join('\n')}\n${getIndentStr(settings, indentLevel - 1)}}`;
+
+        if (parsedSchema.value !== undefined && settings.supplyDefaultsInType) {
+          objectStr = `${wrapValue(parsedSchema.value)} | ${objectStr}`
+        }
       }
       if (doExport) {
         return {
@@ -210,7 +240,7 @@ export function parseSchema(
         return parseBasicSchema(details, settings, rootSchema ?? false);
     }
   }
-  const { interfaceOrTypeName, jsDoc, required } = getCommonDetails(details, settings);
+  const { interfaceOrTypeName, jsDoc, required, value } = getCommonDetails(details, settings);
   if (interfaceOrTypeName && useLabels && !ignoreLabels.includes(interfaceOrTypeName)) {
     // skip parsing and just reference the label since we assumed we parsed the schema that the label references
     // TODO: do we want to use the labels description if we reference it?
@@ -280,6 +310,7 @@ export function parseSchema(
   parsedSchema.interfaceOrTypeName = interfaceOrTypeName;
   parsedSchema.jsDoc = jsDoc;
   parsedSchema.required = required;
+  parsedSchema.value = value;
   return parsedSchema;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,10 @@ export interface Settings {
    * @default '  ' (two spaces)
    */
   readonly indentationChacters: string;
+  /**
+   * If a field has a default and is optional, consider it as required
+   */
+  readonly treatDefaultedOptionalAsRequired: boolean;
 }
 
 export interface ConvertedType {

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,6 +102,11 @@ export interface BaseTypeContent {
    * If this is an object property is it required
    */
   required?: boolean;
+
+  /**
+   * Default value
+   */
+  value?: unknown
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,11 @@ export interface Settings {
    * If a field has a default and is optional, consider it as required
    */
   readonly treatDefaultedOptionalAsRequired: boolean;
+  /**
+   * If a field has a default, modify the resulting field to equal
+   * `field: <default> | type` rather than `field: type`
+   */
+  readonly supplyDefaultsInType: boolean;
 }
 
 export interface ConvertedType {


### PR DESCRIPTION
Thanks for this module, it has simplified my workflow considerably when defining APIs when combined with other modules.

As part of my project I have an API which defines a lot of default values on fields which are otherwise marked as optional (don't really want to force clients to fill in boilerplate cases). A middleware layer then fills in the defaults for anything not set by the client per the supplied schema.

As a result, it means a lot of the types generated include optional members which aren't really optional in the context the generated interfaces are referenced in.

In this PR I've added two new options to settings which, when enabled, do the following:
- Include the default value in the output type (mostly just a visibility thing, happy to drop this if unwanted)
- Mark fields which have a default value as required even if `presence` is not required