### PR TITLE
Fix wrong import of write

### DIFF
--- a/src/convertFilesInDirectory.ts
+++ b/src/convertFilesInDirectory.ts
@@ -1,9 +1,8 @@
 import Path from 'path';
 import { existsSync, lstatSync, mkdirSync, readdirSync } from 'fs';
 import { Settings, GenerateTypeFile, GenerateTypesDir } from './types';
-import { writeIndexFile } from './write';
+import { writeIndexFile, getTypeFileNameFromSchema } from './write';
 import { analyseSchemaFile } from './analyseSchemaFile';
-import { getTypeFileNameFromSchema } from 'write';
 
 /**
  * Create types from schemas from a directory

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { Settings, ConvertedType, InputFileFilter } from './types';
 import { convertFilesInDirectory } from './convertFilesInDirectory';
 import { writeInterfaceFile } from './writeInterfaceFile';
 import { convertSchemaInternal } from './analyseSchemaFile';
-import { writeIndexFile } from 'write';
+import { writeIndexFile } from './write';
 
 export { Settings };
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -10,7 +10,7 @@ import {
   StringDescribe
 } from './joiDescribeTypes';
 import { getAllowValues, getInterfaceOrTypeName, getMetadataFromDetails } from './joiUtils';
-import { getIndentStr, getJsDocString } from 'write';
+import { getIndentStr, getJsDocString } from './write';
 
 // see __tests__/joiTypes.ts for more information
 export const supportedJoiTypes = ['array', 'object', 'alternatives', 'any', 'boolean', 'date', 'number', 'string'];


### PR DESCRIPTION
Hi,

I have the following error when I use the newest version of the lib:

```
Error: Cannot find module 'write'
Require stack:
- XXXX\node_modules\joi-to-typescript\dist\main\parse.js
- XXXX\node_modules\joi-to-typescript\dist\main\analyseSchemaFile.js
- XXXX\node_modules\joi-to-typescript\dist\main\convertFilesInDirectory.js
- XXXX\node_modules\joi-to-typescript\dist\main\index.js
- XXXX\node_modules\@amd\generate-types\dist\index.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
    at Function.Module._resolveFilename.sharedData.moduleResolveFilenameHook.installedValue [as _resolveFilename] (XXXX\node_modules\@cspotcode\source-map-support\source-map-support.js:811:30)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (XXXX\node_modules\joi-to-typescript\dist\main\parse.js:7:17)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Object.require.extensions.<computed> [as .js] (XXXX\node_modules\ts-node\src\index.ts:1587:43)
    at Module.load (node:internal/modules/cjs/loader:981:32) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    'XXXX\\node_modules\\joi-to-typescript\\dist\\main\\parse.js',
    'XXXX\\node_modules\\joi-to-typescript\\dist\\main\\analyseSchemaFile.js',
    'XXXX\\node_modules\\joi-to-typescript\\dist\\main\\convertFilesInDirectory.js',
    'XXXX\\node_modules\\joi-to-typescript\\dist\\main\\index.js',
  ]
}
```

I think the reason is the following import line.

Please let me know what I think, I will check if I get any other problem with the fix.