### PR TITLE
Fix an import-related bug introduced by the `omitIndexFiles` flag

### DIFF
--- a/src/__tests__/noIndex/noIndex.ts
+++ b/src/__tests__/noIndex/noIndex.ts
@@ -1,4 +1,4 @@
-import {existsSync, rmdirSync} from 'fs';
+import {existsSync, readFileSync, rmdirSync} from 'fs';
 
 import {convertFromDirectory} from '../../index';
 
@@ -23,5 +23,10 @@ describe('Create interfaces from schema files but not index files', () => {
 
     expect(existsSync(`${typeOutputDirectory}/index.ts`))
       .toBe(false)
+
+    const fooBarContent = readFileSync(`${typeOutputDirectory}/FooBar.ts`).toString();
+
+    // The import should properly point to a file, and not to the root folder
+    expect(fooBarContent).toContain(`import { InnerInterface } from './Inner';`)
   });
 });

--- a/src/__tests__/noIndex/schemas/FooBarSchema.ts
+++ b/src/__tests__/noIndex/schemas/FooBarSchema.ts
@@ -1,7 +1,9 @@
 import Joi from 'joi';
+import { InnerSchema } from './InnerSchema';
 
 export const BarSchema = Joi.object({
-  id: Joi.number().required().description('Id').example(1)
+  id: Joi.number().required().description('Id').example(1),
+  inner: InnerSchema
 }).meta({ className: 'Bar' });
 
 export const FooSchema = Joi.object({

--- a/src/__tests__/noIndex/schemas/InnerSchema.ts
+++ b/src/__tests__/noIndex/schemas/InnerSchema.ts
@@ -1,0 +1,5 @@
+import Joi from 'joi';
+
+export const InnerSchema = Joi.object({
+  hello: Joi.string()
+}).meta({ className: 'InnerInterface' });

--- a/src/writeInterfaceFile.ts
+++ b/src/writeInterfaceFile.ts
@@ -45,12 +45,18 @@ export async function writeInterfaceFile(
               return value.interfaceOrTypeName === externalCustomType && self.indexOf(value) === index;
             })) {
             if (generatedInternalType && generatedInternalType.location) {
-              if (!customTypeLocationDict[Path.dirname(generatedInternalType.location)]) {
-                customTypeLocationDict[Path.dirname(generatedInternalType.location)] = [];
+              const generatedInternalTypeLocation = settings.omitIndexFiles
+                ? // When we don't want to generate index files it means we need to directly refer
+                  // to each individually generated file
+                  generatedInternalType.location
+                : // Otherwise it's ok to refer to the output directory's path
+                  Path.dirname(generatedInternalType.location);
+              if (!customTypeLocationDict[generatedInternalTypeLocation]) {
+                customTypeLocationDict[generatedInternalTypeLocation] = [];
               }
 
-              if (!customTypeLocationDict[Path.dirname(generatedInternalType.location)].includes(externalCustomType)) {
-                customTypeLocationDict[Path.dirname(generatedInternalType.location)].push(externalCustomType);
+              if (!customTypeLocationDict[generatedInternalTypeLocation].includes(externalCustomType)) {
+                customTypeLocationDict[generatedInternalTypeLocation].push(externalCustomType);
               }
             }
           }


### PR DESCRIPTION
The bug would cause imports of generated types to point to the root generation directory (still expecting an `index.ts` file as if `omitIndexFiles` was `false`) instead of pointing to each individually generated file.

Given the custom scheme (in `./Inner.ts`)

```
import Joi from 'joi';
export const InnerSchema = Joi.object({
  hello: Joi.string()
}).meta({ className: 'InnerInterface' });
```

Imported with (in `./FooBar.ts`):

```
import Joi from 'joi';
import { InnerSchema } from './InnerSchema';

export const BarSchema = Joi.object({
  id: Joi.number().required().description('Id').example(1),
  inner: InnerSchema
}).meta({ className: 'Bar' });
```

Generates (in `interfaces/FooBar.ts`):

With bug (causing TS compilation issues):

```
import { InnerInterface } from '.'
```

After bug fix:

```
import { InnerInterface } from './Inner'
```