### PR TITLE
Alternatives - add support for allowed values

### DIFF
--- a/src/__tests__/alternatives/alternatives.ts
+++ b/src/__tests__/alternatives/alternatives.ts
@@ -72,6 +72,19 @@ export interface Thing {
     }).toThrow();
   });
 
+  test('allowed value in alternatives', () => {
+    const schema = Joi.alternatives(Joi.string(), Joi.number()).allow(null)
+      .meta({ className: 'Test' })
+      .description('Test allowed values in alternatives');
+
+    const result = convertSchema({}, schema);
+    expect(result).not.toBeUndefined();
+    expect(result?.content).toBe(`/**
+ * Test allowed values in alternatives
+ */
+export type Test = string | number | null;`);
+  });
+
   test.skip('blank alternative thrown by joi but extra test if joi changes it', () => {
     expect(() => {
       const invalidSchema = Joi.alternatives()

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -426,7 +426,14 @@ function parseAlternatives(details: AlternativesDescribe, settings: Settings): T
     return undefined;
   }
 
-  return makeTypeContentRoot({ joinOperation: 'union', children, interfaceOrTypeName, jsDoc });
+  const allowedValues = createAllowTypes(details);
+
+  return makeTypeContentRoot({
+    joinOperation: 'union',
+    children: [...children, ...allowedValues],
+    interfaceOrTypeName,
+    jsDoc,
+  });
 }
 
 function buildUnknownTypeContent(unknownType = 'unknown'): TypeContent {


### PR DESCRIPTION
This PR adds support for allowed values in handler of `Joi.alternatives()`