### PR TITLE
Move the `testEnvironment` config key to jest's own config file

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -6,5 +6,6 @@ module.exports = {
   testPathIgnorePatterns: ['/schemas/', '/interfaces/', 'AssertionCriteria'],
   moduleFileExtensions: ['ts', 'js'],
   modulePaths: ['<rootDir>', '<rootDir>/src'],
-  coveragePathIgnorePatterns: ['__tests__', 'examples']
+  coveragePathIgnorePatterns: ['__tests__', 'examples'],
+  testEnvironment: 'node'
 };

--- a/package.json
+++ b/package.json
@@ -54,9 +54,6 @@
   "peerDependencies": {
     "joi": "17.x"
   },
-  "jest": {
-    "testEnvironment": "node"
-  },
   "engines": {
     "node": ">=14.0.0"
   }


### PR DESCRIPTION
Move the `testEnvironment` config key to jest's own config file. 

Having multiple config sources is not allowed:

```
● Multiple configurations found:

    * xxx/joi-to-typescript/jest.config.cjs
    * `jest` key in xxx/joi-to-typescript/package.json

  Implicit config resolution does not allow multiple configuration files.
  Either remove unused config files or select one explicitly with `--config`.

  Configuration Documentation:
  https://jestjs.io/docs/configuration
```