### PR TITLE
Use the plain JSON.stringify function to encode default values

### DIFF
--- a/src/__tests__/defaults/defaults.ts
+++ b/src/__tests__/defaults/defaults.ts
@@ -6,6 +6,7 @@ describe('Test behaviour for optional fields with supplied defaults', function (
   // A junk schema which tests a combination of values and defaults
   const schema = Joi.object({
     str: Joi.string().default('Test'),
+    strWithSpecialChars: Joi.string().default('Test\\World$Hello🚀Hey\nYay'),
     num: Joi.number().default(1),
     bool: Joi.boolean().default(true),
     arr: Joi.array().items(Joi.number()).default([1, 2, 3]),
@@ -47,6 +48,7 @@ describe('Test behaviour for optional fields with supplied defaults', function (
   };
   str?: string;
   strOptional?: string;
+  strWithSpecialChars?: string;
 }`);
   });
   it('Test defaults as required and excluded from types', function () {
@@ -75,6 +77,7 @@ describe('Test behaviour for optional fields with supplied defaults', function (
   };
   str: string;
   strOptional?: string;
+  strWithSpecialChars: string;
 }`);
   });
   it('Test defaults as optional and included in types', function () {
@@ -100,6 +103,7 @@ describe('Test behaviour for optional fields with supplied defaults', function (
   };
   str?: "Test" | string;
   strOptional?: "Test" | string;
+  strWithSpecialChars?: "Test\\\\World$Hello🚀Hey\\nYay" | string;
 }`);
   });
   it('Test defaults as required and included in types', function () {
@@ -125,6 +129,7 @@ describe('Test behaviour for optional fields with supplied defaults', function (
   };
   str: "Test" | string;
   strOptional?: "Test" | string;
+  strWithSpecialChars: "Test\\\\World$Hello🚀Hey\\nYay" | string;
 }`);
   });
 });

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -55,18 +55,6 @@ export function getAllCustomTypes(parsedSchema: TypeContent): string[] {
   return customTypes;
 }
 
-const wrapValue = (value: unknown): string | object | boolean | number => {
-  if (typeof value === 'string') {
-    return `"${value}"`;
-  } else if (Array.isArray(value)) {
-    return `[${value.map(av => wrapValue(av))}]`;
-  } else if (typeof value === 'object') {
-    return JSON.stringify(value);
-  } else {
-    return `${value}`;
-  }
-};
-
 function typeContentToTsHelper(
   settings: Settings,
   parsedSchema: TypeContent,
@@ -77,7 +65,7 @@ function typeContentToTsHelper(
     return {
       tsContent: settings.supplyDefaultsInType
         ? parsedSchema.value !== undefined
-          ? `${wrapValue(parsedSchema.value)} | ${parsedSchema.content}`
+          ? `${JSON.stringify(parsedSchema.value)} | ${parsedSchema.content}`
           : parsedSchema.content
         : parsedSchema.content,
       jsDoc: parsedSchema.jsDoc
@@ -104,7 +92,7 @@ function typeContentToTsHelper(
       }
       const arrayStr = settings.supplyDefaultsInType
         ? parsedSchema.value !== undefined
-          ? `${wrapValue(parsedSchema.value)} | ${content}`
+          ? `${JSON.stringify(parsedSchema.value)} | ${content}`
           : `${content}[]`
         : `${content}[]`;
       if (doExport) {
@@ -142,7 +130,7 @@ function typeContentToTsHelper(
       const unionStr = childrenContent.join(' | ');
       const finalStr = settings.supplyDefaultsInType
         ? parsedSchema.value !== undefined
-          ? `${wrapValue(parsedSchema.value)} | ${unionStr}`
+          ? `${JSON.stringify(parsedSchema.value)} | ${unionStr}`
           : unionStr
         : unionStr;
       if (doExport) {
@@ -180,7 +168,7 @@ function typeContentToTsHelper(
         objectStr = `{\n${childrenContent.join('\n')}\n${getIndentStr(settings, indentLevel - 1)}}`;
 
         if (parsedSchema.value !== undefined && settings.supplyDefaultsInType) {
-          objectStr = `${wrapValue(parsedSchema.value)} | ${objectStr}`;
+          objectStr = `${JSON.stringify(parsedSchema.value)} | ${objectStr}`;
         }
       }
       if (doExport) {


### PR DESCRIPTION
The previous `wrapValue` function was incomplete, in the sense that strings with e.g. backslashes would be encoded in the wrong way. In the end, looking at the overall behavior of `wrapValue`, it seems to want to behave exactly in the same way as `JSON.stringify`, so it may be worth just replacing it once and for all.