### PR TITLE
Wraps function types in additional brackets to prevent broken union types

### DIFF
--- a/src/__tests__/alternatives/alternatives.ts
+++ b/src/__tests__/alternatives/alternatives.ts
@@ -28,6 +28,12 @@ describe('alternative types', () => {
  * Do not modify this file manually
  */
 
+export type AlternativesWithFunctionInterface = ((...args: any[]) => any) | {
+  json: any;
+} | {
+  raw: string;
+};
+
 /**
  * a description for basic
  */
@@ -73,7 +79,8 @@ export interface Thing {
   });
 
   test('allowed value in alternatives', () => {
-    const schema = Joi.alternatives(Joi.string(), Joi.number()).allow(null)
+    const schema = Joi.alternatives(Joi.string(), Joi.number())
+      .allow(null)
       .meta({ className: 'Test' })
       .description('Test allowed values in alternatives');
 

--- a/src/__tests__/alternatives/schemas/OneSchema.ts
+++ b/src/__tests__/alternatives/schemas/OneSchema.ts
@@ -35,3 +35,13 @@ export const AlternativesConditionalSchema = Joi.object({
     otherwise: Joi.forbidden()
   })
 }).meta({ className: 'SomeSchema' });
+
+export const AlternativesWithFunctionSchema = Joi.alternatives([
+  Joi.function().minArity(2),
+  Joi.object({
+    json: Joi.any().required()
+  }),
+  Joi.object({
+    raw: Joi.string().required()
+  })
+]).meta({ className: 'AlternativesWithFunctionInterface' });

--- a/src/__tests__/joiTypes.ts
+++ b/src/__tests__/joiTypes.ts
@@ -43,9 +43,9 @@ describe('`Joi.types()`', () => {
     expect(result?.content).toBe(
       [
         'export interface Test {',
-        '  doStuff?: (...args: any[]) => any;',
-        '  moreThings?: (...args: any[]) => any;',
-        '  stuff: (...args: any[]) => any;',
+        '  doStuff?: ((...args: any[]) => any);',
+        '  moreThings?: ((...args: any[]) => any);',
+        '  stuff: ((...args: any[]) => any);',
         '}'
       ].join('\n')
     );

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -278,7 +278,7 @@ export function parseSchema(
     if (typeToUse === undefined) {
       switch (details.type as string) {
         case 'function':
-          typeToUse = '(...args: any[]) => any';
+          typeToUse = '((...args: any[]) => any)';
           break;
 
         case 'symbol':


### PR DESCRIPTION
E.g. take this schema:

```
export const AlternativesWithFunctionSchema = Joi.alternatives([
  Joi.function().minArity(2),
  Joi.object({
    json: Joi.any().required()
  }),
  Joi.object({
    raw: Joi.string().required()
  })
]).meta({ className: 'AlternativesWithFunctionInterface' });
```

Without brackets, a chain would have become

```
(...args: any[]) => any | {
  json: any;
} | {
  raw: string;
};
```

In this type, the whole `any | { json: any; } | { raw: string; }` is the return type of the function, which is wrong.

With brackets, it will be:

```
export type AlternativesWithFunctionInterface = ((...args: any[]) => any) | {
  json: any;
} | {
  raw: string;
};
```

There could be some more advanced logic to figure out if we want the brackets or not depending if we're using a union or not, but I feel it is even safer in general to just wrap function types in brackets given the "unsupported" nature of the Function type.

Note: this will conflict on merge with https://github.com/mrjono1/joi-to-typescript/pull/401. I'll take care of it if merged. Probably one test will fail.