### PR TITLE
Add missing `export type` notation for unsupported types

### DIFF
--- a/src/__tests__/joiTypes.ts
+++ b/src/__tests__/joiTypes.ts
@@ -51,6 +51,14 @@ describe('`Joi.types()`', () => {
     );
   });
 
+  test('Joi.function() bare value', () => {
+    const schema = Joi.function().meta({ className: 'Test' });
+
+    const result = convertSchema({ debug: true }, schema);
+    expect(result).not.toBeUndefined;
+    expect(result?.content).toBe(['export type Test = (...args: any[]) => any;'].join('\n'));
+  });
+
   // TODO: It might be possible to support link
   // I guess this would find the referenced schema and get its type
   test('Joi.link()', () => {

--- a/src/__tests__/joiTypes.ts
+++ b/src/__tests__/joiTypes.ts
@@ -56,7 +56,7 @@ describe('`Joi.types()`', () => {
 
     const result = convertSchema({ debug: true }, schema);
     expect(result).not.toBeUndefined;
-    expect(result?.content).toBe(['export type Test = (...args: any[]) => any;'].join('\n'));
+    expect(result?.content).toBe(['export type Test = ((...args: any[]) => any);'].join('\n'));
   });
 
   // TODO: It might be possible to support link

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,5 +1,5 @@
 import { filterMap, isDescribe, toStringLiteral } from './utils';
-import { TypeContent, makeTypeContentRoot, makeTypeContentChild, Settings, JsDoc } from './types';
+import { JsDoc, makeTypeContentChild, makeTypeContentRoot, Settings, TypeContent } from './types';
 import {
   AlternativesDescribe,
   ArrayDescribe,
@@ -62,12 +62,20 @@ function typeContentToTsHelper(
   doExport = false
 ): { tsContent: string; jsDoc?: JsDoc } {
   if (!parsedSchema.__isRoot) {
+    const tsContent = settings.supplyDefaultsInType
+      ? parsedSchema.value !== undefined
+        ? `${JSON.stringify(parsedSchema.value)} | ${parsedSchema.content}`
+        : parsedSchema.content
+      : parsedSchema.content;
+    if (doExport) {
+      return {
+        tsContent: `export type ${parsedSchema.interfaceOrTypeName} = ${tsContent};`,
+        jsDoc: parsedSchema.jsDoc
+      };
+    }
+
     return {
-      tsContent: settings.supplyDefaultsInType
-        ? parsedSchema.value !== undefined
-          ? `${JSON.stringify(parsedSchema.value)} | ${parsedSchema.content}`
-          : parsedSchema.content
-        : parsedSchema.content,
+      tsContent,
       jsDoc: parsedSchema.jsDoc
     };
   }


### PR DESCRIPTION
Previously, a definition like

```
export const TestSchema = Joi.function().meta({ className: 'Test' });
```

was exporting broken TS code:

```
(...args: any[]) => any;
```

It now exports:

```
export type Test = (...args: any[]) => any;
```

Note: this will conflict on merge with https://github.com/mrjono1/joi-to-typescript/pull/400. I'll take care of it if merged. Probably one test will fail.