### PR TITLE
Add the `ignoreDescription` flag, which can be used to NOT print a description for a schema, even if it has been defined previously.

### DIFF
--- a/src/__tests__/description/index.ts
+++ b/src/__tests__/description/index.ts
@@ -52,6 +52,40 @@ export interface ExampleLong {
 }
 
 /**
+ * IgnoreDescription
+ */
+export interface IgnoreDescription {
+  /**
+   * thing
+   */
+  thing: string;
+}
+
+/**
+ * IgnoreDescriptionObject
+ */
+export interface IgnoreDescriptionObject {
+  /**
+   * withDescription
+   */
+  withDescription?: {
+    /**
+     * A simple description
+     */
+    [x: string]: Example;
+  };
+  /**
+   * withoutDescription
+   */
+  withoutDescription?: {
+    /**
+     * [x: string]
+     */
+    [x: string]: Example;
+  };
+}
+
+/**
  * NoComment
  */
 export interface NoComment {

--- a/src/__tests__/description/schemas/OneSchema.ts
+++ b/src/__tests__/description/schemas/OneSchema.ts
@@ -18,3 +18,11 @@ And more here!
 export const noCommentSchema = Joi.object({
   more: Joi.string().required()
 }).meta({ className: 'NoComment' });
+
+export const ignoreDescriptionSchema = exampleSchema.meta({ className: 'IgnoreDescription', ignoreDescription: true });
+export const ignoreDescriptionObjectSchema = Joi.object({
+  withDescription: Joi.object().pattern(Joi.string(), exampleSchema).meta({ unknownType: exampleSchema }),
+  withoutDescription: Joi.object()
+    .pattern(Joi.string(), exampleSchema)
+    .meta({ unknownType: exampleSchema.meta({ ignoreDescription: true }) })
+}).meta({ className: 'IgnoreDescriptionObject' });

--- a/src/joiUtils.ts
+++ b/src/joiUtils.ts
@@ -29,6 +29,16 @@ export function getIsReadonly(details: Describe): boolean | undefined {
   return undefined;
 }
 
+export function getIgnoreDescription(details: Describe): boolean | undefined {
+  const ignoreDescriptionItems = getMetadataFromDetails('ignoreDescription', details);
+  if (ignoreDescriptionItems.length !== 0) {
+    const ignoreDescription = ignoreDescriptionItems.pop();
+    return Boolean(ignoreDescription);
+  }
+
+  return undefined;
+}
+
 /**
  * Get the interface name from the Joi
  * @returns a string if it can find one

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -9,7 +9,13 @@ import {
   ObjectDescribe,
   StringDescribe
 } from './joiDescribeTypes';
-import { getAllowValues, getInterfaceOrTypeName, getIsReadonly, getMetadataFromDetails } from './joiUtils';
+import {
+  getAllowValues,
+  getIgnoreDescription,
+  getInterfaceOrTypeName,
+  getIsReadonly,
+  getMetadataFromDetails
+} from './joiUtils';
 import { getIndentStr, getJsDocString } from './write';
 
 // see __tests__/joiTypes.ts for more information
@@ -25,7 +31,8 @@ function getCommonDetails(
 ): { interfaceOrTypeName?: string; jsDoc: JsDoc; required: boolean; value?: unknown; isReadonly?: boolean } {
   const interfaceOrTypeName = getInterfaceOrTypeName(settings, details);
 
-  const description = details.flags?.description;
+  const ignoreDescription = getIgnoreDescription(details);
+  const description = ignoreDescription ? undefined : details.flags?.description;
   const presence = details.flags?.presence;
   const value = details.flags?.default;
   const example = details.examples?.[0];


### PR DESCRIPTION
This can also be useful when dealing with objects with patterns and the `unknownType` meta. In such cases, the description of the `unknownType` is propagated to the map entry, creating sometimes a bit of confusion because the description belongs to each map entry's value and not its key.