### PR TITLE
Add a spacing between JsDoc description and any additional examples

### DIFF
--- a/src/__tests__/allowValid/index.ts
+++ b/src/__tests__/allowValid/index.ts
@@ -158,11 +158,13 @@ export interface Parent {
     expect(result?.content).toBe(`export interface TestSchema {
   /**
    * The password of the authenticating user
+   *
    * @example test-PASSWORD123
    */
   password: string;
   /**
    * Repeat the password to ensure no typos
+   *
    * @example test-PASSWORD123
    */
   repeatPassword: string;

--- a/src/__tests__/description/index.ts
+++ b/src/__tests__/description/index.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, rmdirSync } from 'fs';
 
-import { convertFromDirectory } from '../../index';
+import { convertFromDirectory, convertSchema } from '../../index';
+import Joi from 'joi';
 
 describe('description', () => {
   const typeOutputDirectory = './src/__tests__/description/interfaces';
@@ -30,6 +31,7 @@ describe('description', () => {
 
 /**
  * A schema with an example
+ *
  * @example
  * {
  *   "more": "world"
@@ -44,6 +46,7 @@ export interface DescriptionAndExample {
 
 /**
  * A schema with two examples
+ *
  * @example
  * {
  *   "more": "world"
@@ -62,6 +65,7 @@ export interface DescriptionAndExamples {
 
 /**
  * A schema with a short example
+ *
  * @example One liner
  */
 export interface DescriptionAndShortExample {
@@ -124,6 +128,7 @@ export interface ExampleLong {
 
 /**
  * ExampleNewLine
+ *
  * @example
  * I have many
  * lines!
@@ -146,5 +151,55 @@ export interface NoComment {
 }
 `
     );
+  });
+
+  it('Test JsDoc example spacing', function () {
+    {
+      const converted = convertSchema(
+        {},
+        Joi.object({
+          hello: Joi.string()
+        }).example({
+          hello: 'world'
+        }),
+        'HelloTest'
+      );
+      expect(converted).toBeDefined();
+      expect(converted?.content).toEqual(`/**
+ * @example
+ * {
+ *   "hello": "world"
+ * }
+ */
+export interface HelloTest {
+  hello?: string;
+}`);
+    }
+
+    {
+      const converted = convertSchema(
+        {},
+        Joi.object({
+          hello: Joi.string()
+        })
+          .description('A simple description')
+          .example({
+            hello: 'world'
+          }),
+        'HelloTest'
+      );
+      expect(converted).toBeDefined();
+      expect(converted?.content).toEqual(`/**
+ * A simple description
+ *
+ * @example
+ * {
+ *   "hello": "world"
+ * }
+ */
+export interface HelloTest {
+  hello?: string;
+}`);
+    }
   });
 });

--- a/src/__tests__/fromFile/fromFile.ts
+++ b/src/__tests__/fromFile/fromFile.ts
@@ -65,6 +65,7 @@ export interface TestSchema {
 export interface Bar {
   /**
    * Id
+   *
    * @example 1
    */
   id: number;
@@ -77,6 +78,7 @@ export interface Foo {
   bar: Bar;
   /**
    * Id
+   *
    * @example 1
    */
   id: number;

--- a/src/write.ts
+++ b/src/write.ts
@@ -51,7 +51,7 @@ export function getJsDocString(settings: Settings, name: string, jsDoc?: JsDoc, 
     return '';
   }
 
-  const lines = ['/**'];
+  const lines = [];
 
   if (settings.commentEverything || (jsDoc && jsDoc.description)) {
     let description = name;
@@ -59,6 +59,11 @@ export function getJsDocString(settings: Settings, name: string, jsDoc?: JsDoc, 
       description = jsDoc.description.trim();
     }
     lines.push(...description.split('\n').map(line => ` * ${line}`.trimEnd()));
+  }
+
+  // Add a JsDoc divider if needed
+  if ((jsDoc?.examples?.length ?? 0) > 0 && lines.length > 0) {
+    lines.push(' *');
   }
 
   for (const example of jsDoc?.examples ?? []) {
@@ -72,6 +77,9 @@ export function getJsDocString(settings: Settings, name: string, jsDoc?: JsDoc, 
     }
   }
 
+  // Add JsDoc boundaries
+  lines.unshift('/**');
   lines.push(' */');
+
   return lines.map(line => `${getIndentStr(settings, indentLevel)}${line}`).join('\n') + '\n';
 }


### PR DESCRIPTION
I feel comments become more readable with spacing 🤔 

```
/**
 * A simple description
 * @example
 * {
 *   "hello": "world"
 * }
 * @example
 * {
 *   "hello": "world2"
 * }
 */
export interface HelloTest {
  hello?: string;
}
```

vs 

```
/**
 * A simple description
 * 
 * @example
 * {
 *   "hello": "world"
 * }
 * @example
 * {
 *   "hello": "world2"
 * }
 */
export interface HelloTest {
  hello?: string;
}
```