### PR TITLE
Support raw empty objects

### DIFF
--- a/src/__tests__/basic.ts
+++ b/src/__tests__/basic.ts
@@ -116,4 +116,133 @@ export interface ArrayObject {
     expect(result).not.toBeUndefined;
     expect(result?.content).toBe(`export interface Test {}`);
   });
+
+  describe('empty object', () => {
+    test('empty object ts generation', () => {
+      const schema = Joi.object({
+        field1: Joi.string(),
+        // Raw empty object
+        nothing1: {},
+        // Joi should allow any key/pair value here, as per docs: https://joi.dev/api/?v=17.9.1#object
+        // "Defaults to allowing any child key."
+        nothing2: Joi.object(),
+        // In this case we forcefully communicate this is a EMPTY object.
+        nothing3: Joi.object({}),
+        nothingAppend: Joi.object().append({ hello: Joi.string() }),
+        allowUnknown1: Joi.object().unknown(true),
+        allowUnknown2: Joi.object({}).unknown(true),
+        appended: Joi.object({}).append({ field1: Joi.string() }),
+        nothingAlternative: Joi.alternatives([Joi.object({}), Joi.object()])
+      }).meta({ className: 'Test' });
+
+      const result = convertSchema({ sortPropertiesByName: false }, schema);
+      expect(result).not.toBeUndefined;
+      expect(result?.content).toBe(`export interface Test {
+  field1?: string;
+  nothing1?: {};
+  nothing2?: object;
+  nothing3?: {};
+  nothingAppend?: {
+    hello?: string;
+  };
+  allowUnknown1?: {
+    /**
+     * Unknown Property
+     */
+    [x: string]: unknown;
+  };
+  allowUnknown2?: {
+    /**
+     * Unknown Property
+     */
+    [x: string]: unknown;
+  };
+  appended?: {
+    field1?: string;
+  };
+  nothingAlternative?: {} | object;
+}`);
+    });
+
+    describe('empty object matching', () => {
+      const tests: {
+        schema: Joi.Schema;
+        value: any;
+        error?: boolean;
+      }[] = [
+        {
+          schema: Joi.object(),
+          value: {},
+          error: false
+        },
+        // When no args are passed, unknown values are allowed by default
+        {
+          schema: Joi.object(),
+          value: {
+            hello: 'world'
+          },
+          error: false
+        },
+        {
+          schema: Joi.object({}),
+          value: {},
+          error: false
+        },
+        // When explicitly defining {}, no unknown values are allowed by default
+        {
+          schema: Joi.object({}),
+          value: {
+            hello: 'world'
+          },
+          error: true
+        },
+        {
+          schema: Joi.object().unknown(false),
+          value: {},
+          error: false
+        },
+        {
+          schema: Joi.object({}).unknown(false),
+          value: {},
+          error: false
+        },
+        {
+          schema: Joi.object().unknown(false),
+          value: {
+            hello: 'world'
+          },
+          // Maybe unexpected but this is how Joi works.
+          error: false
+        },
+        {
+          schema: Joi.object({}).unknown(false),
+          value: {
+            hello: 'world'
+          },
+          error: true
+        },
+        {
+          schema: Joi.object().unknown(true),
+          value: {},
+          error: false
+        },
+        {
+          schema: Joi.object().unknown(true),
+          value: {
+            hello: 'world'
+          },
+          error: false
+        }
+      ];
+
+      test.each(tests)('%#', t => {
+        const result = t.schema.validate(t.value);
+        if (t.error) {
+          expect(result.error).not.toBeUndefined();
+        } else {
+          expect(result.error).toBeUndefined();
+        }
+      });
+    });
+  });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -173,7 +173,7 @@ export interface TypeContentRoot extends BaseTypeContent {
   /**
    * How to join the children types together
    */
-  joinOperation: 'list' | 'tuple' | 'union' | 'intersection' | 'object';
+  joinOperation: 'list' | 'tuple' | 'union' | 'intersection' | 'object' | 'objectWithUndefinedKeys';
 
   /**
    * Children types


### PR DESCRIPTION
There is a peculiar Joi detail where `Joi.object()` and `Joi.object({})` behave in different ways:

* `Joi.object()` allows by default any key/value pair.
* `Joi.object({})` DOES NOT allow by default any key/value pair.

When generating TS definitions, `Joi.object()` is perfectly represented by `object`, but `Joi.object({})` should be a forcefully empty object `{}`.

This PR addresses this last situation.