### PR TITLE
Fix an edge case where the user does not pass ANY content to the `alternatives` function.

### DIFF
--- a/src/__tests__/alternatives/alternatives.ts
+++ b/src/__tests__/alternatives/alternatives.ts
@@ -28,6 +28,10 @@ describe('alternative types', () => {
  * Do not modify this file manually
  */
 
+export interface AlternativesArrayOptionalInterface {
+  oneOrTheOtherMaybe: (number | string | undefined)[];
+}
+
 export type AlternativesWithFunctionInterface = ((...args: any[]) => any) | {
   json: any;
 } | {

--- a/src/__tests__/alternatives/schemas/OneSchema.ts
+++ b/src/__tests__/alternatives/schemas/OneSchema.ts
@@ -45,3 +45,9 @@ export const AlternativesWithFunctionSchema = Joi.alternatives([
     raw: Joi.string().required()
   })
 ]).meta({ className: 'AlternativesWithFunctionInterface' });
+
+export const AlternativesArrayOptional = Joi.object({
+  oneOrTheOtherMaybe: Joi.array()
+    .items(Joi.alternatives([Joi.number(), Joi.string(), Joi.alternatives()]))
+    .required()
+}).meta({ className: 'AlternativesArrayOptionalInterface' });


### PR DESCRIPTION
In the official docs: If no schemas are added, the type will not match any value except for undefined.