### PR TITLE
Add `unionNewLine` and `tupleNewLine` settings to force newline styling for unions and tuples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,14 @@ export interface Settings {
    * generated interface/type code.
    */
   tsContentFooter?: (type: ConvertedType) => string;
+  /**
+   * If defined, place every member of a union on a new line
+   */
+  unionNewLine?: boolean;
+  /**
+   * If defined, place every member of a tuple on a new line
+   */
+  tupleNewLine?: boolean;
 }
 ```
 

--- a/src/__tests__/alternatives/alternatives.ts
+++ b/src/__tests__/alternatives/alternatives.ts
@@ -188,6 +188,32 @@ export interface Test {
 }`);
   });
 
+  test('union newlines with defaults', () => {
+    const schema = Joi.object({
+      items: Joi.alternatives([Joi.string(), Joi.number()]).default('hello')
+    })
+      .description('An object')
+      .meta({ className: 'Test' });
+
+    const result = convertSchema(
+      {
+        unionNewLine: true,
+        supplyDefaultsInType: true
+      },
+      schema
+    );
+    expect(result).not.toBeUndefined();
+    expect(result?.content).toBe(`/**
+ * An object
+ */
+export interface Test {
+  items?:
+    | "hello"
+    | string
+    | number;
+}`);
+  });
+
   test.skip('blank alternative thrown by joi but extra test if joi changes it', () => {
     expect(() => {
       const invalidSchema = Joi.alternatives()

--- a/src/__tests__/alternatives/alternatives.ts
+++ b/src/__tests__/alternatives/alternatives.ts
@@ -102,6 +102,45 @@ export interface Thing {
 export type Test = string | number | null;`);
   });
 
+  test('union newlines', () => {
+    const schema = Joi.object({
+      items: Joi.alternatives(Joi.string(), Joi.number().description('A number')).description(
+        'Test allowed values in alternatives'
+      ),
+      otherItems: Joi.alternatives(Joi.string(), Joi.number()).description('Test allowed values in alternatives')
+    })
+      .description('An object')
+      .meta({ className: 'Test' });
+
+    const result = convertSchema(
+      {
+        unionNewLine: true
+      },
+      schema
+    );
+    expect(result).not.toBeUndefined();
+    expect(result?.content).toBe(`/**
+ * An object
+ */
+export interface Test {
+  /**
+   * Test allowed values in alternatives
+   */
+  items?:
+    | string
+    /**
+     * A number
+     */
+    | number;
+  /**
+   * Test allowed values in alternatives
+   */
+  otherItems?:
+    | string
+    | number;
+}`);
+  });
+
   test.skip('blank alternative thrown by joi but extra test if joi changes it', () => {
     expect(() => {
       const invalidSchema = Joi.alternatives()

--- a/src/__tests__/alternatives/alternatives.ts
+++ b/src/__tests__/alternatives/alternatives.ts
@@ -141,6 +141,31 @@ export interface Test {
 }`);
   });
 
+  test('union newlines 2', () => {
+    const schema = Joi.object({
+      items: Joi.alternatives([Joi.string(), Joi.string().allow(null)])
+    })
+      .description('An object')
+      .meta({ className: 'Test' });
+
+    const result = convertSchema(
+      {
+        unionNewLine: true
+      },
+      schema
+    );
+    expect(result).not.toBeUndefined();
+    expect(result?.content).toBe(`/**
+ * An object
+ */
+export interface Test {
+  items?:
+    | string
+    | string
+    | null;
+}`);
+  });
+
   test.skip('blank alternative thrown by joi but extra test if joi changes it', () => {
     expect(() => {
       const invalidSchema = Joi.alternatives()

--- a/src/__tests__/alternatives/alternatives.ts
+++ b/src/__tests__/alternatives/alternatives.ts
@@ -28,11 +28,17 @@ describe('alternative types', () => {
  * Do not modify this file manually
  */
 
+export interface AlternativesObjectNoDesc {
+  myVal?: number | string;
+}
+
+export type AlternativesRawNoDesc = number | string;
+
 export type AlternativesWithFunctionInterface = ((...args: any[]) => any) | {
-  json: any;
-} | {
-  raw: string;
-};
+    json: any;
+  } | {
+    raw: string;
+  };
 
 /**
  * a description for basic

--- a/src/__tests__/alternatives/alternatives.ts
+++ b/src/__tests__/alternatives/alternatives.ts
@@ -166,6 +166,28 @@ export interface Test {
 }`);
   });
 
+  test('union newlines one entry', () => {
+    const schema = Joi.object({
+      items: Joi.alternatives([Joi.string()])
+    })
+      .description('An object')
+      .meta({ className: 'Test' });
+
+    const result = convertSchema(
+      {
+        unionNewLine: true
+      },
+      schema
+    );
+    expect(result).not.toBeUndefined();
+    expect(result?.content).toBe(`/**
+ * An object
+ */
+export interface Test {
+  items?: string;
+}`);
+  });
+
   test.skip('blank alternative thrown by joi but extra test if joi changes it', () => {
     expect(() => {
       const invalidSchema = Joi.alternatives()

--- a/src/__tests__/alternatives/schemas/OneSchema.ts
+++ b/src/__tests__/alternatives/schemas/OneSchema.ts
@@ -45,3 +45,12 @@ export const AlternativesWithFunctionSchema = Joi.alternatives([
     raw: Joi.string().required()
   })
 ]).meta({ className: 'AlternativesWithFunctionInterface' });
+
+export const alternativesRawNoDescSchema = Joi.alternatives([Joi.number(), Joi.string()]).meta({
+  className: 'AlternativesRawNoDesc',
+  disableDescription: true
+});
+
+export const alternativesObjectNoDescSchema = Joi.object({
+  myVal: Joi.alternatives([Joi.number(), Joi.string()])
+}).meta({ className: 'AlternativesObjectNoDesc', disableDescription: true });

--- a/src/__tests__/defaults/defaults.ts
+++ b/src/__tests__/defaults/defaults.ts
@@ -35,8 +35,8 @@ describe('Test behaviour for optional fields with supplied defaults', function (
     expect(converted?.content).toEqual(`export interface Test {
   alt?: string | number;
   alt2?: string | number | {
-    val?: boolean;
-  };
+      val?: boolean;
+    };
   arr?: number[];
   arr2?: string[];
   bool?: boolean;
@@ -64,8 +64,8 @@ describe('Test behaviour for optional fields with supplied defaults', function (
     expect(converted?.content).toEqual(`export interface Test {
   alt: string | number;
   alt2: string | number | {
-    val: boolean;
-  };
+      val: boolean;
+    };
   arr: number[];
   arr2: string[];
   bool: boolean;
@@ -90,8 +90,8 @@ describe('Test behaviour for optional fields with supplied defaults', function (
     expect(converted?.content).toEqual(`export interface Test {
   alt?: "Test" | string | number;
   alt2?: {"val":false} | string | number | {
-    val?: true | boolean;
-  };
+      val?: true | boolean;
+    };
   arr?: [1,2,3] | number[];
   arr2?: ["X","Y","Z"] | string[];
   bool?: true | boolean;
@@ -116,8 +116,8 @@ describe('Test behaviour for optional fields with supplied defaults', function (
     expect(converted?.content).toEqual(`export interface Test {
   alt: "Test" | string | number;
   alt2: {"val":false} | string | number | {
-    val: true | boolean;
-  };
+      val: true | boolean;
+    };
   arr: [1,2,3] | number[];
   arr2: ["X","Y","Z"] | string[];
   bool: true | boolean;

--- a/src/__tests__/description/index.ts
+++ b/src/__tests__/description/index.ts
@@ -114,6 +114,121 @@ export interface Example {
 }
 
 /**
+ * ExampleAlternatives
+ */
+export interface ExampleAlternatives {
+  /**
+   * alt1
+   */
+  alt1?:
+    /**
+     * A string
+     */
+    | string
+    /**
+     * A number
+     */
+    | number
+    /**
+     * An object
+     */
+    | {
+      /**
+       * A value
+       */
+      value?: string;
+    }
+    /**
+     * An array
+     */
+    | string[]
+    /**
+     * A tuple
+     */
+    | [number,
+      /**
+       * A string
+       */
+       string,
+      Item?
+    ] | null
+    /**
+     * Another tuple
+     */
+    | [
+      /**
+       * A tuple number
+       */
+      number,
+      string
+    ]
+    /**
+     * A tuple with one item
+     */
+    | [
+      /**
+       * A tuple number
+       */
+      number
+    ];
+}
+
+/**
+ * ExampleAlternativesRaw
+ */
+export type ExampleAlternativesRaw =
+  /**
+   * A string
+   */
+  | string
+  /**
+   * A number
+   */
+  | number
+  /**
+   * An object
+   */
+  | {
+    /**
+     * A value
+     */
+    value?: string;
+  }
+  /**
+   * An array
+   */
+  | string[]
+  /**
+   * A tuple
+   */
+  | [number,
+    /**
+     * A string
+     */
+     string,
+    Item?
+  ] | null
+  /**
+   * Another tuple
+   */
+  | [
+    /**
+     * A tuple number
+     */
+    number,
+    string
+  ]
+  /**
+   * A tuple with one item
+   */
+  | [
+    /**
+     * A tuple number
+     */
+    number
+  ];
+
+/**
  * This is a long indented description.
  * There are many lines!
  *
@@ -152,6 +267,16 @@ export interface ExampleNewLine {
    * more
    */
   more: string;
+}
+
+/**
+ * Item
+ */
+export interface Item {
+  /**
+   * name
+   */
+  name: string;
 }
 
 /**

--- a/src/__tests__/description/schemas/OneSchema.ts
+++ b/src/__tests__/description/schemas/OneSchema.ts
@@ -81,3 +81,49 @@ export const descriptionAndExamplesSchema = Joi.object({
     more: 'coffee'
   })
   .meta({ className: 'DescriptionAndExamples' });
+
+export const ItemSchema = Joi.object({
+  name: Joi.string().required()
+}).meta({ className: 'Item' });
+
+export const exampleAlternativesSchema = Joi.object({
+  alt1: Joi.alternatives([
+    Joi.string().description('A string'),
+    Joi.number().description('A number'),
+    Joi.object({
+      value: Joi.string().description(`A value`)
+    }).description('An object'),
+    Joi.array().items(Joi.string()).description(`An array`),
+    Joi.array()
+      .ordered(Joi.number().required())
+      .ordered(Joi.string().required().description(`A string`))
+      .ordered(ItemSchema)
+      .allow(null)
+      .description(`A tuple`),
+    Joi.array()
+      .ordered(Joi.number().required().description('A tuple number'))
+      .ordered(Joi.string().required())
+      .description(`Another tuple`),
+    Joi.array().ordered(Joi.number().required().description('A tuple number')).description(`A tuple with one item`)
+  ])
+}).meta({ className: 'ExampleAlternatives' });
+
+export const exampleAlternativesRawSchema = Joi.alternatives([
+  Joi.string().description('A string'),
+  Joi.number().description('A number'),
+  Joi.object({
+    value: Joi.string().description(`A value`)
+  }).description('An object'),
+  Joi.array().items(Joi.string()).description(`An array`),
+  Joi.array()
+    .ordered(Joi.number().required())
+    .ordered(Joi.string().required().description(`A string`))
+    .ordered(ItemSchema)
+    .allow(null)
+    .description(`A tuple`),
+  Joi.array()
+    .ordered(Joi.number().required().description('A tuple number'))
+    .ordered(Joi.string().required())
+    .description(`Another tuple`),
+  Joi.array().ordered(Joi.number().required().description('A tuple number')).description(`A tuple with one item`)
+]).meta({ className: 'ExampleAlternativesRaw' });

--- a/src/__tests__/tuple/tuple.ts
+++ b/src/__tests__/tuple/tuple.ts
@@ -70,4 +70,81 @@ export type TestTuple = [
  */
 export type TestList = any[];`);
   });
+
+  test('tuple newline', () => {
+    const schema = Joi.object({
+      name: Joi.string().optional(),
+      propertyName1: Joi.bool().required(),
+      items: Joi.array()
+        .ordered(Joi.number().required())
+        .ordered(Joi.string().required())
+        .ordered(
+          Joi.object({
+            another: Joi.string()
+          })
+        )
+        .allow(null),
+      simpleItems: Joi.array().ordered(Joi.number().required()).ordered(Joi.string().required())
+    })
+      .meta({ className: 'Test' })
+      .description('a test schema definition');
+
+    const result = convertSchema({ sortPropertiesByName: true, tupleNewLine: true }, schema);
+    expect(result).not.toBeUndefined;
+    expect(result?.content).toBe(`/**
+ * a test schema definition
+ */
+export interface Test {
+  items?: [
+      number,
+      string,
+      {
+        another?: string;
+      }?
+    ] | null;
+  name?: string;
+  propertyName1: boolean;
+  simpleItems?: [
+    number,
+    string
+  ];
+}`);
+  });
+
+  test('tuple and union newline', () => {
+    const schema = Joi.object({
+      name: Joi.string().optional(),
+      propertyName1: Joi.bool().required(),
+      items: Joi.array()
+        .ordered(Joi.number().required())
+        .ordered(Joi.string().required())
+        .ordered(
+          Joi.object({
+            another: Joi.string()
+          })
+        )
+        .allow(null)
+    })
+      .meta({ className: 'Test' })
+      .description('a test schema definition');
+
+    const result = convertSchema({ sortPropertiesByName: true, tupleNewLine: true, unionNewLine: true }, schema);
+    expect(result).not.toBeUndefined;
+    expect(result?.content).toBe(`/**
+ * a test schema definition
+ */
+export interface Test {
+  items?:
+    | [
+      number,
+      string,
+      {
+        another?: string;
+      }?
+    ]
+    | null;
+  name?: string;
+  propertyName1: boolean;
+}`);
+  });
 });

--- a/src/__tests__/tuple/tuple.ts
+++ b/src/__tests__/tuple/tuple.ts
@@ -44,7 +44,13 @@ export interface Test {
 /**
  * A tuple of Test object
  */
-export type TestTuple = [Test, (number | string)?];
+export type TestTuple = [
+  /**
+   * a test schema definition
+   */
+  Test,
+  (number | string)?
+];
 `
     );
   });
@@ -56,8 +62,6 @@ export type TestTuple = [Test, (number | string)?];
       .required()
       .meta({ className: 'TestList' })
       .description('A list of Test object');
-
-
 
     const result = convertSchema({ sortPropertiesByName: true }, schema);
     expect(result).not.toBeUndefined;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -191,12 +191,13 @@ function typeContentToTsHelper(
           childContent += child.required ? '' : '?';
         }
         childContent += itemIdx < children.length - 1 ? itemSeparatorAfterItem : '';
-        if (descriptionStr != '') {
+        if (descriptionStr != '' || (!isTuple && settings.unionNewLine) || (isTuple && settings.tupleNewLine)) {
           // If there is a description it means we also have a new line, which means
           // we need to properly indent the following line too.
+          const prefix = descriptionStr != '' ? descriptionStr : first ? '' : '\n';
           childrenContent.push(
             (first ? '\n' : '') +
-              `${descriptionStr}${indentString}${itemSeparatorAfterNewline}${childInfoTsContentPrefix}${childContent}`
+              `${prefix}${indentString}${itemSeparatorAfterNewline}${childInfoTsContentPrefix}${childContent}`
           );
           previousIsInline = false;
         } else {
@@ -214,7 +215,9 @@ function typeContentToTsHelper(
       finalStr = childrenContent.join(hasOneDescription ? '\n' : '');
 
       if (isTuple) {
-        finalStr = `[${finalStr}${hasOneDescription ? '\n' + getIndentStr(settings, indentLevel - 1) : ''}]`;
+        finalStr = `[${finalStr}${hasOneDescription ? '\n' + getIndentStr(settings, indentLevel - 1) : ''}${
+          settings.tupleNewLine ? '\n' + getIndentStr(settings, indentLevel - 1) : ''
+        }]`;
       }
 
       if (doExport) {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -199,7 +199,10 @@ function typeContentToTsHelper(
           }
         }
         childContent += itemIdx < children.length - 1 ? itemSeparatorAfterItem : '';
-        if (descriptionStr != '' || (!isTuple && settings.unionNewLine) || (isTuple && settings.tupleNewLine)) {
+        if (
+          descriptionStr != '' ||
+          (children.length > 1 && ((!isTuple && settings.unionNewLine) || (isTuple && settings.tupleNewLine)))
+        ) {
           // If there is a description it means we also have a new line, which means
           // we need to properly indent the following line too.
           const prefix = descriptionStr != '' ? descriptionStr : first ? '' : skipNewline ? '' : '\n';

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -16,7 +16,7 @@ import {
   getIsReadonly,
   getMetadataFromDetails
 } from './joiUtils';
-import { getIndentStr, getJsDocString } from './write';
+import { getIndentStr, getJsDocString } from './write'; // see __tests__/joiTypes.ts for more information
 
 // see __tests__/joiTypes.ts for more information
 export const supportedJoiTypes = ['array', 'object', 'alternatives', 'any', 'boolean', 'date', 'number', 'string'];
@@ -134,39 +134,95 @@ function typeContentToTsHelper(
       }
       return { tsContent: arrayStr, jsDoc: parsedSchema.jsDoc };
     }
-    case 'tuple': {
-      const childrenContent = children.map(child => {
-        let { tsContent } = typeContentToTsHelper(settings, child, indentLevel);
+    case 'tuple':
+    case 'union': {
+      const isTuple = parsedSchema.joinOperation == 'tuple';
 
-        if (tsContent.includes('|')) {
-          tsContent = `(${tsContent})`;
+      const indentString = getIndentStr(settings, indentLevel);
+      const itemSeparatorBeforeItem = isTuple ? '' : ' |';
+      const itemSeparatorAfterItem = isTuple ? ',' : '';
+      const itemSeparatorAfterNewline = isTuple ? '' : '|';
+
+      let hasOneDescription = false;
+      let finalStr: string;
+
+      const childrenContent: string[] = [];
+      let first = true;
+      let previousIsInline = false;
+      if (settings.supplyDefaultsInType && parsedSchema.value !== undefined) {
+        childrenContent.push(JSON.stringify(parsedSchema.value));
+        previousIsInline = true;
+        first = false;
+      }
+      for (let itemIdx = 0; itemIdx < children.length; itemIdx++) {
+        const child = children[itemIdx];
+        const childInfo = typeContentToTsHelper(
+          settings,
+          child,
+          // Special case for objects because their contents need to be indented once more
+          child.__isRoot && ['object', 'list', 'tuple'].includes(child.joinOperation) ? indentLevel + 1 : indentLevel
+        );
+        const descriptionStr = getJsDocString(
+          settings,
+          child.interfaceOrTypeName as string,
+          childInfo.jsDoc,
+          indentLevel
+        );
+        hasOneDescription ||= descriptionStr != '';
+
+        // Prevents test failures because of spaces at line endings
+        let childInfoTsContentPrefix = '';
+        if (isTuple) {
+          if (previousIsInline) {
+            childInfoTsContentPrefix = ' ';
+          }
+        } else {
+          childInfoTsContentPrefix = childInfo.tsContent.startsWith('\n') ? '' : ' ';
         }
 
-        return `${tsContent}${child.required ? '' : '?'}`;
-      });
+        /*
+          Compose the child code line. If there is a description, it must be above the entry.
+           */
+        let childContent = childInfo.tsContent;
+        if (isTuple) {
+          if (childContent.includes('|')) {
+            childContent = `(${childContent})`;
+          }
+          childContent += child.required ? '' : '?';
+        }
+        childContent += itemIdx < children.length - 1 ? itemSeparatorAfterItem : '';
+        if (descriptionStr != '') {
+          // If there is a description it means we also have a new line, which means
+          // we need to properly indent the following line too.
+          childrenContent.push(
+            (first ? '\n' : '') +
+              `${descriptionStr}${indentString}${itemSeparatorAfterNewline}${childInfoTsContentPrefix}${childContent}`
+          );
+          previousIsInline = false;
+        } else {
+          // Normal inline content
+          childrenContent.push(
+            (first
+              ? ''
+              : (previousIsInline ? itemSeparatorBeforeItem : indentString + itemSeparatorAfterNewline) +
+                childInfoTsContentPrefix) + childContent
+          );
+          previousIsInline = true;
+        }
+        first = false;
+      }
+      finalStr = childrenContent.join(hasOneDescription ? '\n' : '');
 
-      const tupleStr = `[${childrenContent.join(', ')}]`;
-
-      if (doExport) {
-        return {
-          tsContent: `export type ${parsedSchema.interfaceOrTypeName} = ${tupleStr};`,
-          jsDoc: parsedSchema.jsDoc
-        };
+      if (isTuple) {
+        finalStr = `[${finalStr}${hasOneDescription ? '\n' + getIndentStr(settings, indentLevel - 1) : ''}]`;
       }
 
-      return { tsContent: tupleStr, jsDoc: parsedSchema.jsDoc };
-    }
-    case 'union': {
-      const childrenContent = children.map(child => typeContentToTsHelper(settings, child, indentLevel).tsContent);
-      const unionStr = childrenContent.join(' | ');
-      const finalStr = settings.supplyDefaultsInType
-        ? parsedSchema.value !== undefined
-          ? `${JSON.stringify(parsedSchema.value)} | ${unionStr}`
-          : unionStr
-        : unionStr;
       if (doExport) {
         return {
-          tsContent: `export type ${parsedSchema.interfaceOrTypeName} = ${finalStr};`,
+          tsContent: `export type ${parsedSchema.interfaceOrTypeName} =${
+            // Prevents test failures because of spaces at line endings
+            finalStr.startsWith('\n') ? '' : ' '
+          }${finalStr};`,
           jsDoc: parsedSchema.jsDoc
         };
       }
@@ -199,7 +255,18 @@ function typeContentToTsHelper(
           const optionalStr = child.required ? '' : '?';
           const indentString = getIndentStr(settings, indentLevel);
           const modifier = child.isReadonly ? 'readonly ' : '';
-          return `${descriptionStr}${indentString}${modifier}${child.interfaceOrTypeName}${optionalStr}: ${childInfo.tsContent};`;
+          return [
+            descriptionStr,
+            indentString,
+            modifier,
+            child.interfaceOrTypeName,
+            optionalStr,
+            ':',
+            // Prevents test failures because of spaces at line endings
+            childInfo.tsContent.startsWith('\n') ? '' : ' ',
+            childInfo.tsContent,
+            ';'
+          ].join('');
         });
         objectStr = `{\n${childrenContent.join('\n')}\n${getIndentStr(settings, indentLevel - 1)}}`;
 
@@ -271,17 +338,18 @@ export function parseSchema(
   if (interfaceOrTypeName && useLabels && !ignoreLabels.includes(interfaceOrTypeName)) {
     // skip parsing and just reference the label since we assumed we parsed the schema that the label references
     // TODO: do we want to use the labels description if we reference it?
+    let allowedValues = createAllowTypes(details);
 
     const child = makeTypeContentChild({
       content: interfaceOrTypeName,
       customTypes: [interfaceOrTypeName],
-      jsDoc,
+      // If we have any allowed values, remove the jsDoc from the child as we will use it in the outer object
+      jsDoc: allowedValues.length > 0 ? undefined : jsDoc,
       required,
       isReadonly
     });
 
-    let allowedValues = createAllowTypes(details);
-    if (allowedValues.length !== 0) {
+    if (allowedValues.length > 0) {
       if (!details.flags?.only) {
         allowedValues.unshift(child);
       } else {
@@ -373,7 +441,7 @@ function parseBasicSchema(details: BasicDescribe, settings: Settings, rootSchema
   if (rootSchema) {
     return makeTypeContentRoot({
       joinOperation: 'union',
-      children: [makeTypeContentChild({ content, interfaceOrTypeName, jsDoc })],
+      children: [makeTypeContentChild({ content, interfaceOrTypeName })],
       interfaceOrTypeName,
       jsDoc
     });
@@ -426,7 +494,7 @@ function parseStringSchema(details: StringDescribe, settings: Settings, rootSche
   if (rootSchema) {
     return makeTypeContentRoot({
       joinOperation: 'union',
-      children: [makeTypeContentChild({ content: 'string', interfaceOrTypeName, jsDoc })],
+      children: [makeTypeContentChild({ content: 'string', interfaceOrTypeName })],
       interfaceOrTypeName,
       jsDoc
     });
@@ -444,13 +512,12 @@ function parseArray(details: ArrayDescribe, settings: Settings): TypeContent | u
     const allowedValues = createAllowTypes(details);
 
     // at least one value
-    if (allowedValues.length !== 0) {
+    if (allowedValues.length > 0) {
       allowedValues.unshift(
         makeTypeContentRoot({
           joinOperation: 'tuple',
           children: parsedChildren,
-          interfaceOrTypeName,
-          jsDoc
+          interfaceOrTypeName
         })
       );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,6 +114,16 @@ export interface Settings {
    * generated interface/type code.
    */
   readonly tsContentFooter?: (type: ConvertedType) => string;
+
+  /**
+   * If defined, place every member of a union on a new line
+   */
+  readonly unionNewLine?: boolean;
+
+  /**
+   * If defined, place every member of a tuple on a new line
+   */
+  readonly tupleNewLine?: boolean;
 }
 
 export class InputFileFilter {

--- a/src/write.ts
+++ b/src/write.ts
@@ -58,7 +58,9 @@ export function getJsDocString(settings: Settings, name: string, jsDoc?: JsDoc, 
     if (jsDoc?.description) {
       description = getStringIndentation(jsDoc.description).deIndentedString;
     }
-    lines.push(...description.split('\n').map(line => ` * ${line}`.trimEnd()));
+    if (description) {
+      lines.push(...description.split('\n').map(line => ` * ${line}`.trimEnd()));
+    }
   }
 
   // Add a JsDoc divider if needed
@@ -75,6 +77,10 @@ export function getJsDocString(settings: Settings, name: string, jsDoc?: JsDoc, 
     } else {
       lines.push(` * @example ${deIndented}`);
     }
+  }
+
+  if (lines.length == 0) {
+    return '';
   }
 
   // Add JsDoc boundaries


### PR DESCRIPTION
Note: this is based/dependent on https://github.com/mrjono1/joi-to-typescript/pull/412

Add:

```
  /**
   * If defined, place every member of a union on a new line
   */
  unionNewLine?: boolean;
  /**
   * If defined, place every member of a tuple on a new line
   */
  tupleNewLine?: boolean;
```

When used, these settings can help formatting the generated code to improve its readability.

## More context

This PR was born because I was investigating a prettier bug that would cause JsDocs of union types to be "squashed", e.g. this code:

```
  /**
   * The items to iterate over.
   */
  items:
    /**
     * An array to iterate over.
     */
    | any[]
    /**
     * An object to iterate over.
     */
    | object;
  /**
   * Another comment
   */
```

becomes:

```
  /**
   * The items to iterate over.
   */
  items: /** <----------------- This is a bug
   * An array to iterate over. <---- The indentation is broken
   */
  | any[]

    /**
     * An object to iterate over.
     */
    | object;

  /**
   * Another comment
   */
```

So, I went on the way of "let's disable prettier" and explored around, and I realized that having such two settings can by default improve the readability of types.