### PR TITLE
Also expose the original schema in the `ConvertedType` interface

### DIFF
--- a/src/analyseSchemaFile.ts
+++ b/src/analyseSchemaFile.ts
@@ -52,6 +52,7 @@ export function convertSchemaInternal(
     const customTypes = getAllCustomTypes(parsedSchema);
     const content = typeContentToTs(settings, parsedSchema, true);
     return {
+      schema: joi,
       interfaceOrTypeName,
       customTypes,
       content

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import Joi from 'joi';
+
 /**
  * Application settings
  */
@@ -132,6 +134,7 @@ export class InputFileFilter {
 }
 
 export interface ConvertedType {
+  schema: Joi.Schema;
   interfaceOrTypeName: string;
   content: string;
   customTypes: string[];


### PR DESCRIPTION
Also expose the original schema in the `ConvertedType` interface, which e.g. allows inspecting it in the `tsContentHeader` and `tsContentFooter` calls.