### PR TITLE
Ignore the `{"special": "deep"}` default value introduced by Joi when invoking the `default()` function without arguments.

### DIFF
--- a/src/__tests__/defaults/defaults.ts
+++ b/src/__tests__/defaults/defaults.ts
@@ -132,4 +132,21 @@ describe('Test behaviour for optional fields with supplied defaults', function (
   strWithSpecialChars: "Test\\\\World$Hello🚀Hey\\nYay" | string;
 }`);
   });
+  it('Test defaults when using the empty default constructor', function () {
+    const converted = convertSchema(
+      { supplyDefaultsInType: true, treatDefaultedOptionalAsRequired: true },
+      Joi.object({
+        str: Joi.string().default('Test'),
+        strWithSpecialChars: Joi.string().default('Test\\World$Hello🚀Hey\nYay'),
+        num: Joi.number().default(1)
+      }).default(),
+      'Test'
+    );
+    expect(converted).toBeDefined();
+    expect(converted?.content).toEqual(`export interface Test {
+  num: 1 | number;
+  str: "Test" | string;
+  strWithSpecialChars: "Test\\\\World$Hello🚀Hey\\nYay" | string;
+}`);
+  });
 });

--- a/src/__tests__/defaults/defaults.ts
+++ b/src/__tests__/defaults/defaults.ts
@@ -149,4 +149,30 @@ describe('Test behaviour for optional fields with supplied defaults', function (
   strWithSpecialChars: "Test\\\\World$Hello🚀Hey\\nYay" | string;
 }`);
   });
+  it('Test defaults when using the empty default constructor (user-provided value)', function () {
+    const converted = convertSchema(
+      { supplyDefaultsInType: true, treatDefaultedOptionalAsRequired: true },
+      Joi.object({
+        special: Joi.string()
+      }).default({ special: 'deep' }),
+      'Test'
+    );
+    expect(converted).toBeDefined();
+    expect(converted?.content).toEqual(`export interface Test {
+  special?: string;
+}`);
+  });
+  it('Test defaults when using an user-provided value', function () {
+    const converted = convertSchema(
+      { supplyDefaultsInType: true, treatDefaultedOptionalAsRequired: true },
+      Joi.object({
+        something: Joi.string()
+      }).default({ something: 'deep' }),
+      'Test'
+    );
+    expect(converted).toBeDefined();
+    expect(converted?.content).toEqual(`export type Test = {"something":"deep"} | {
+  something?: string;
+}`);
+  });
 });

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -301,6 +301,7 @@ function typeContentToTsHelper(
 
       // interface can have no properties {} if the joi object has none defined
       let objectStr = '{}';
+      let hasDefault = false;
 
       if (children.length !== 0) {
         const childrenContent = children.map(child => {
@@ -333,9 +334,16 @@ function typeContentToTsHelper(
 
         if (parsedSchema.value !== undefined && settings.supplyDefaultsInType) {
           objectStr = getDefaultTypeTsContent(settings, indentLevel, parsedSchema, objectStr);
+          hasDefault = true;
         }
       }
       if (doExport) {
+        if (hasDefault) {
+          return {
+            tsContent: `export type ${parsedSchema.interfaceOrTypeName} = ${objectStr}`,
+            jsDoc: parsedSchema.jsDoc
+          };
+        }
         return {
           tsContent: `export interface ${parsedSchema.interfaceOrTypeName} ${objectStr}`,
           jsDoc: parsedSchema.jsDoc

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -45,6 +45,7 @@ function getCommonDetails(
     // a schema entry, Joi adds a special symbol to the entry, which
     // is converted to {"special": "deep"} via describe.
     // When this case comes up, we can ignore it.
+    // Ref: https://github.com/hapijs/joi/blob/e7e9c5d18dafaa510a7ece02c225653db5fc998f/lib/manifest.js#L179
     value = undefined;
   }
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -33,7 +33,20 @@ function getCommonDetails(
 
   const description = details.flags?.description;
   const presence = details.flags?.presence;
-  const value = details.flags?.default;
+  let value = details.flags?.default;
+  if (
+    value &&
+    typeof value === 'object' &&
+    'special' in value &&
+    value.special === 'deep' &&
+    Object.keys(value).length === 1
+  ) {
+    // Special case. When using the empty `default()` function on
+    // a schema entry, Joi adds a special symbol to the entry, which
+    // is converted to {"special": "deep"} via describe.
+    // When this case comes up, we can ignore it.
+    value = undefined;
+  }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const examples: string[] = ((details.examples || []) as any[])


### PR DESCRIPTION
Ignore the `{"special": "deep"}` default value introduced by Joi when invoking the `default()` function without arguments.

Ref: https://github.com/hapijs/joi/blob/e7e9c5d18dafaa510a7ece02c225653db5fc998f/lib/manifest.js#L179

Without this fix, the generated TS code would look like:

```ts
export interface Test {"special":"deep"} | {
  num: 1 | number;
  str: "Test" | string;
  strWithSpecialChars: "Test\\World$Hello🚀Hey\nYay" | string;
}
```

Note: there is an edge case here where if someone were to use the `{"special":"deep"}` values as default, this would not be printed in the generated type default. I think it's an acceptable "bug" because the Joi library dumps this value in the result of the describe function without providing additional information. 

---

Also, fix the generated types in case we have objects with default values, where we then need to use `export type =` instead of `export interface` because the latter one is invalid with a union.

So, instead of the invalid

```ts
export interface Test {"something":"deep"} | {
  something?: string;
}
```

we get the proper

```ts
export type Test = {"something":"deep"} | {
  something?: string;
}
```