### PR TITLE
Add the `supplyDefaultsInJsDoc` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,12 @@ export interface Settings {
    */
   supplyDefaultsInType: boolean;
   /**
+   * If a field has a default value, add its stringified representation
+   * to the JsDoc using the @default annotation
+   * @default false
+   */
+  supplyDefaultsInJsDoc: boolean;
+  /**
    * Filter files you wish to parse
    * The class `InputFileFilter` contains some default options
    * @default *.ts files

--- a/src/__tests__/defaults/defaults.ts
+++ b/src/__tests__/defaults/defaults.ts
@@ -151,7 +151,7 @@ describe('Test behaviour for optional fields with supplied defaults', function (
   });
   it('Test defaults when using the empty default constructor (user-provided value)', function () {
     const converted = convertSchema(
-      { supplyDefaultsInType: true, treatDefaultedOptionalAsRequired: true },
+      { supplyDefaultsInType: true, supplyDefaultsInJsDoc: true, treatDefaultedOptionalAsRequired: true },
       Joi.object({
         special: Joi.string()
       }).default({ special: 'deep' }),

--- a/src/__tests__/defaults/defaults.ts
+++ b/src/__tests__/defaults/defaults.ts
@@ -180,18 +180,22 @@ describe('Test behaviour for optional fields with supplied defaults', function (
       { supplyDefaultsInJsDoc: true },
       schema.append({
         fieldWithDoc: Joi.string().description('A field with a\nmultiline doc').default('My string!'),
-        fieldWithAnyNull: Joi.any().default(null)
+        fieldWithAnyNull: Joi.any().default(null),
+        fieldWithMultilineString: Joi.string().default(`A multiline\nstring with\nsome lines`),
+        fieldWithBigDefault: Joi.array()
+          .items(Joi.string())
+          .default(['i', 'have', 'more', 'than', '5', 'values', 'more', 'more', 'more'])
       }),
       'Test'
     );
     expect(converted).toBeDefined();
     expect(converted?.content).toEqual(`export interface Test {
   /**
-   * @default "Test"
+   * @default 'Test'
    */
   alt?: string | number;
   /**
-   * @default {"val":false}
+   * @default { val: false }
    */
   alt2?: string | number | {
       /**
@@ -200,11 +204,11 @@ describe('Test behaviour for optional fields with supplied defaults', function (
       val?: boolean;
     };
   /**
-   * @default [1,2,3]
+   * @default [ 1, 2, 3 ]
    */
   arr?: number[];
   /**
-   * @default ["X","Y","Z"]
+   * @default [ 'X', 'Y', 'Z' ]
    */
   arr2?: string[];
   /**
@@ -220,12 +224,27 @@ describe('Test behaviour for optional fields with supplied defaults', function (
    */
   fieldWithAnyNull?: any;
   /**
+   * @default
+   * [
+   *   'i',    'have',
+   *   'more', 'than',
+   *   '5',    'values',
+   *   'more', 'more',
+   *   'more'
+   * ]
+   */
+  fieldWithBigDefault?: string[];
+  /**
    * A field with a
    * multiline doc
    *
-   * @default "My string!"
+   * @default 'My string!'
    */
   fieldWithDoc?: string;
+  /**
+   * @default 'A multiline\\nstring with\\nsome lines'
+   */
+  fieldWithMultilineString?: string;
   /**
    * @default 1
    */
@@ -235,21 +254,21 @@ describe('Test behaviour for optional fields with supplied defaults', function (
    */
   numOptional?: number;
   /**
-   * @default {"val":"Test"}
+   * @default { val: 'Test' }
    */
   obj?: {
     val?: string;
   };
   /**
-   * @default "Test"
+   * @default 'Test'
    */
   str?: string;
   /**
-   * @default "Test"
+   * @default 'Test'
    */
   strOptional?: string;
   /**
-   * @default "Test\\\\World$Hello🚀Hey\\nYay"
+   * @default 'Test\\\\World$Hello🚀Hey\\nYay'
    */
   strWithSpecialChars?: string;
 }`);

--- a/src/__tests__/defaults/defaults.ts
+++ b/src/__tests__/defaults/defaults.ts
@@ -175,4 +175,83 @@ describe('Test behaviour for optional fields with supplied defaults', function (
   something?: string;
 }`);
   });
+  it('Adds defaults to docs', function () {
+    const converted = convertSchema(
+      { supplyDefaultsInJsDoc: true },
+      schema.append({
+        fieldWithDoc: Joi.string().description('A field with a\nmultiline doc').default('My string!'),
+        fieldWithAnyNull: Joi.any().default(null)
+      }),
+      'Test'
+    );
+    expect(converted).toBeDefined();
+    expect(converted?.content).toEqual(`export interface Test {
+  /**
+   * @default "Test"
+   */
+  alt?: string | number;
+  /**
+   * @default {"val":false}
+   */
+  alt2?: string | number | {
+      /**
+       * @default true
+       */
+      val?: boolean;
+    };
+  /**
+   * @default [1,2,3]
+   */
+  arr?: number[];
+  /**
+   * @default ["X","Y","Z"]
+   */
+  arr2?: string[];
+  /**
+   * @default true
+   */
+  bool?: boolean;
+  /**
+   * @default true
+   */
+  boolOptional?: boolean;
+  /**
+   * @default null
+   */
+  fieldWithAnyNull?: any;
+  /**
+   * A field with a
+   * multiline doc
+   *
+   * @default "My string!"
+   */
+  fieldWithDoc?: string;
+  /**
+   * @default 1
+   */
+  num?: number;
+  /**
+   * @default 1
+   */
+  numOptional?: number;
+  /**
+   * @default {"val":"Test"}
+   */
+  obj?: {
+    val?: string;
+  };
+  /**
+   * @default "Test"
+   */
+  str?: string;
+  /**
+   * @default "Test"
+   */
+  strOptional?: string;
+  /**
+   * @default "Test\\\\World$Hello🚀Hey\\nYay"
+   */
+  strWithSpecialChars?: string;
+}`);
+  });
 });

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -16,7 +16,8 @@ import {
   getIsReadonly,
   getMetadataFromDetails
 } from './joiUtils';
-import { getIndentStr, getJsDocString } from './write'; // see __tests__/joiTypes.ts for more information
+import { getIndentStr, getJsDocString } from './write';
+import util from 'node:util'; // see __tests__/joiTypes.ts for more information
 
 // see __tests__/joiTypes.ts for more information
 export const supportedJoiTypes = ['array', 'object', 'alternatives', 'any', 'boolean', 'date', 'number', 'string'];
@@ -51,7 +52,7 @@ function getCommonDetails(
 
   const defaultJsDoc =
     settings.supplyDefaultsInJsDoc && details.flags && 'default' in details.flags
-      ? JSON.stringify(details.flags.default)
+      ? util.inspect(details.flags.default, { depth: null })
       : undefined;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -51,9 +51,7 @@ function getCommonDetails(
   }
 
   const defaultJsDoc =
-    settings.supplyDefaultsInJsDoc && details.flags && 'default' in details.flags
-      ? util.inspect(details.flags.default, { depth: null })
-      : undefined;
+    settings.supplyDefaultsInJsDoc && value !== undefined ? util.inspect(value, { depth: null }) : undefined;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const examples: string[] = ((details.examples || []) as any[])

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -49,6 +49,11 @@ function getCommonDetails(
     value = undefined;
   }
 
+  const defaultJsDoc =
+    settings.supplyDefaultsInJsDoc && details.flags && 'default' in details.flags
+      ? JSON.stringify(details.flags.default)
+      : undefined;
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const examples: string[] = ((details.examples || []) as any[])
     .filter(e => e !== undefined)
@@ -75,7 +80,7 @@ function getCommonDetails(
   }
   return {
     interfaceOrTypeName,
-    jsDoc: { description, examples, disable: disableJsDoc },
+    jsDoc: { description, examples, default: defaultJsDoc, disable: disableJsDoc },
     required,
     value,
     isReadonly

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,9 +90,15 @@ export interface Settings {
   /**
    * If a field has a default, modify the resulting field to equal
    * `field: <default> | type` rather than `field: type`
-   * @defatult false
+   * @default false
    */
   readonly supplyDefaultsInType: boolean;
+  /**
+   * If a field has a default value, add its stringified representation
+   * to the JsDoc using the @default annotation
+   * @default false
+   */
+  readonly supplyDefaultsInJsDoc: boolean;
   /**
    * Filter files you wish to parse
    * The class `InputFileFilter` contains some default options
@@ -317,6 +323,10 @@ export interface JsDoc {
    * @example example values
    */
   examples?: string[];
+  /**
+   * @default default value
+   */
+  default?: string;
   /**
    * If true, completely disables printing JsDoc
    */

--- a/src/write.ts
+++ b/src/write.ts
@@ -47,7 +47,7 @@ export function getJsDocString(settings: Settings, name: string, jsDoc?: JsDoc, 
     return '';
   }
 
-  if (!settings.commentEverything && !jsDoc?.description && (jsDoc?.examples?.length ?? 0) === 0) {
+  if (!settings.commentEverything && !jsDoc?.description && !jsDoc?.default && (jsDoc?.examples?.length ?? 0) === 0) {
     return '';
   }
 
@@ -64,8 +64,19 @@ export function getJsDocString(settings: Settings, name: string, jsDoc?: JsDoc, 
   }
 
   // Add a JsDoc divider if needed
-  if ((jsDoc?.examples?.length ?? 0) > 0 && lines.length > 0) {
+  if (((jsDoc?.examples?.length ?? 0) > 0 || jsDoc?.default) && lines.length > 0) {
     lines.push(' *');
+  }
+
+  if (jsDoc?.default) {
+    const deIndented = getStringIndentation(jsDoc.default).deIndentedString;
+
+    if (deIndented.includes('\n')) {
+      lines.push(` * @default`);
+      lines.push(...deIndented.split('\n').map(line => ` * ${line}`.trimEnd()));
+    } else {
+      lines.push(` * @default ${deIndented}`);
+    }
   }
 
   for (const example of jsDoc?.examples ?? []) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 6
+  version: 8
   cacheKey: 10
 
 "@aashutoshrathi/word-wrap@npm:^1.2.3":
@@ -1193,17 +1193,17 @@ __metadata:
   version: 7.1.0
   resolution: "@typescript-eslint/parser@npm:7.1.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 7.1.0
-    "@typescript-eslint/types": 7.1.0
-    "@typescript-eslint/typescript-estree": 7.1.0
-    "@typescript-eslint/visitor-keys": 7.1.0
-    debug: ^4.3.4
+    "@typescript-eslint/scope-manager": "npm:7.1.0"
+    "@typescript-eslint/types": "npm:7.1.0"
+    "@typescript-eslint/typescript-estree": "npm:7.1.0"
+    "@typescript-eslint/visitor-keys": "npm:7.1.0"
+    debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.56.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 8/3c518414a0ccb7b16c17dfcf9bffe9e6dae1fe19640e265ce1fb2d896ea072fdb7e498c4f12f8b1517a0869f9660e64c33447d0ef7b2ce856a1d0d6d49ce2749
+  checksum: 39238d37f5a5f7058371ee3882fb7cd8a4579883fc5f13fda645c151fcf8d15e4c0db3ea7ffa7915a55c82451b544e9340c0228b45b83085158cb97974112f19
   languageName: node
   linkType: hard
 
@@ -1221,9 +1221,9 @@ __metadata:
   version: 7.1.0
   resolution: "@typescript-eslint/scope-manager@npm:7.1.0"
   dependencies:
-    "@typescript-eslint/types": 7.1.0
-    "@typescript-eslint/visitor-keys": 7.1.0
-  checksum: 8/737c010cb60eedb2824038995150146a2099b09d0194ee0e7a2b730f29603775eba54b5260731a26e1056c4cdcc1847b5ea505228e9c240b6e31e3ed4b7a1d75
+    "@typescript-eslint/types": "npm:7.1.0"
+    "@typescript-eslint/visitor-keys": "npm:7.1.0"
+  checksum: 3fb18de864331739c1b04fe9e3bb5d926e2fdf0d1fea2871181f68d0fb52325cbc9a5b81da58b7fe7f22d6d58d62b21c83460907146bc2f54ef0720fb3f9037f
   languageName: node
   linkType: hard
 
@@ -1254,7 +1254,7 @@ __metadata:
 "@typescript-eslint/types@npm:7.1.0":
   version: 7.1.0
   resolution: "@typescript-eslint/types@npm:7.1.0"
-  checksum: 8/ad1e95ee83e9af7569c61260e62e4f4a42c8b82c57c33880c24dba44d1ab6792f5063e71ddf5176a1846b97158caba456805271787785250a937bba0e3df06d0
+  checksum: 34801a14ea1444a1707de5bd3211f0ea53afc82a3c6c4543092f123267389da607c498d1a7de554ac9f071e6ef488238728a5f279ff2abaa0cbdfaa733899b67
   languageName: node
   linkType: hard
 
@@ -1280,18 +1280,18 @@ __metadata:
   version: 7.1.0
   resolution: "@typescript-eslint/typescript-estree@npm:7.1.0"
   dependencies:
-    "@typescript-eslint/types": 7.1.0
-    "@typescript-eslint/visitor-keys": 7.1.0
-    debug: ^4.3.4
-    globby: ^11.1.0
-    is-glob: ^4.0.3
-    minimatch: 9.0.3
-    semver: ^7.5.4
-    ts-api-utils: ^1.0.1
+    "@typescript-eslint/types": "npm:7.1.0"
+    "@typescript-eslint/visitor-keys": "npm:7.1.0"
+    debug: "npm:^4.3.4"
+    globby: "npm:^11.1.0"
+    is-glob: "npm:^4.0.3"
+    minimatch: "npm:9.0.3"
+    semver: "npm:^7.5.4"
+    ts-api-utils: "npm:^1.0.1"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 8/a4db9f2b5094f3fdeaa09ca93ffefe23a7cfab3924c870b7277d36d1f9e3e9e0bd4fb10d9a4bae75d4ce5c0d1a0193888742f080e7f43a9f1b6d105f05f570c0
+  checksum: 7dfc6fc70ff00875728ce5d85a3c5d6cb01435082b20ff9301ebe4d8e4a31a0c997282c762c636937bd66a40b4e0154e2ce98f85d888a6c46d433e9a24c46c4c
   languageName: node
   linkType: hard
 
@@ -1327,9 +1327,9 @@ __metadata:
   version: 7.1.0
   resolution: "@typescript-eslint/visitor-keys@npm:7.1.0"
   dependencies:
-    "@typescript-eslint/types": 7.1.0
-    eslint-visitor-keys: ^3.4.1
-  checksum: 8/7ddac02dde4e16960ca87f0c05e5c5176fef6203bbf39d217ae15f8db498c262677a5799a258960a8d6bbcbc2ffbb799841e32276d2867f1e2f88bd988606092
+    "@typescript-eslint/types": "npm:7.1.0"
+    eslint-visitor-keys: "npm:^3.4.1"
+  checksum: c3e98ebf166fd1854adb0e9599dc108cdbbd95f6eb099d31deae2fd1d4df8fcd8dc9c24ad4f509b961ad900b474c246f6b4b228b5711cc504106c3e0f751a11c
   languageName: node
   linkType: hard
 
@@ -2378,9 +2378,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@npm%3A^2.3.2#~builtin<compat/fsevents>":
+"fsevents@patch:fsevents@npm%3A^2.3.2#optional!builtin<compat/fsevents>":
   version: 2.3.2
-  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
   dependencies:
     node-gyp: "npm:latest"
   conditions: os=darwin
@@ -2649,7 +2649,7 @@ __metadata:
 "ip@npm:^2.0.0":
   version: 2.0.1
   resolution: "ip@npm:2.0.1"
-  checksum: 8/d765c9fd212b8a99023a4cde6a558a054c298d640fec1020567494d257afd78ca77e37126b1a3ef0e053646ced79a816bf50621d38d5e768cdde0431fa3b0d35
+  checksum: d6dd154e1bc5e8725adfdd6fb92218635b9cbe6d873d051bd63b178f009777f751a5eea4c67021723a7056325fc3052f8b6599af0a2d56f042c93e684b4a0349
   languageName: node
   linkType: hard
 
@@ -3276,18 +3276,18 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "joi-to-typescript@workspace:."
   dependencies:
-    "@types/jest": 29.5.11
-    "@types/node": 18.15.11
-    "@typescript-eslint/eslint-plugin": 5.62.0
-    "@typescript-eslint/parser": 7.1.0
-    eslint: 8.55.0
-    eslint-config-prettier: 9.1.0
-    eslint-plugin-prettier: 5.1.3
-    jest: 29.7.0
-    joi: 17.12.2
-    prettier: 3.2.5
-    ts-jest: 29.1.2
-    typescript: 5.3.3
+    "@types/jest": "npm:29.5.11"
+    "@types/node": "npm:18.15.11"
+    "@typescript-eslint/eslint-plugin": "npm:5.62.0"
+    "@typescript-eslint/parser": "npm:7.1.0"
+    eslint: "npm:8.55.0"
+    eslint-config-prettier: "npm:9.1.0"
+    eslint-plugin-prettier: "npm:5.1.3"
+    jest: "npm:29.7.0"
+    joi: "npm:17.12.2"
+    prettier: "npm:3.2.5"
+    ts-jest: "npm:29.1.2"
+    typescript: "npm:5.3.3"
   peerDependencies:
     joi: 17.x
   languageName: unknown
@@ -3297,12 +3297,12 @@ __metadata:
   version: 17.12.2
   resolution: "joi@npm:17.12.2"
   dependencies:
-    "@hapi/hoek": ^9.3.0
-    "@hapi/topo": ^5.1.0
-    "@sideway/address": ^4.1.5
-    "@sideway/formula": ^3.0.1
-    "@sideway/pinpoint": ^2.0.0
-  checksum: 8/5a5213c56d3a3b769b4cb999756a226d090421693443a405a9f1063443941a8b920c731b0c2cad526163726494c2da9858d38a98d39bd516df60e9ef49f0125a
+    "@hapi/hoek": "npm:^9.3.0"
+    "@hapi/topo": "npm:^5.1.0"
+    "@sideway/address": "npm:^4.1.5"
+    "@sideway/formula": "npm:^3.0.1"
+    "@sideway/pinpoint": "npm:^2.0.0"
+  checksum: 42257382802f622a4152cc4dbf5bca226a312a8315bf826262f5643d8e450d2f2d9c753abfef247b8c3121423639a02945b322ccac5abde17402dedcb26b9365
   languageName: node
   linkType: hard
 
@@ -3939,7 +3939,7 @@ __metadata:
   resolution: "prettier@npm:3.2.5"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 8/2ee4e1417572372afb7a13bb446b34f20f1bf1747db77cf6ccaf57a9be005f2f15c40f903d41a6b79eec3f57fff14d32a20fb6dee1f126da48908926fe43c311
+  checksum: d509f9da0b70e8cacc561a1911c0d99ec75117faed27b95cc8534cb2349667dee6351b0ca83fa9d5703f14127faa52b798de40f5705f02d843da133fc3aa416a
   languageName: node
   linkType: hard
 
@@ -4059,16 +4059,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.20.0#~builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>":
   version: 1.22.2
-  resolution: "resolve@patch:resolve@npm%3A1.22.2#~builtin<compat/resolve>::version=1.22.2&hash=c3c19d"
+  resolution: "resolve@patch:resolve@npm%3A1.22.2#optional!builtin<compat/resolve>::version=1.22.2&hash=c3c19d"
   dependencies:
     is-core-module: "npm:^2.11.0"
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 8/66cc788f13b8398de18eb4abb3aed90435c84bb8935953feafcf7231ba4cd191b2c10b4a87b1e9681afc34fb138c705f91f7330ff90bfa36f457e5584076a2b8
+  checksum: 14594f99dbff19c1f51f6daac0caf0b75ed345256ada3722c23f63935eace79532dcfa349b3d8889d2771c143822c38dd5d7d8eb85fb8cff257b7abccbad7872
   languageName: node
   linkType: hard
 
@@ -4422,7 +4422,7 @@ __metadata:
   resolution: "ts-api-utils@npm:1.2.1"
   peerDependencies:
     typescript: ">=4.2.0"
-  checksum: 8/17a2a4454d65a6765b9351304cfd516fcda3098f49d72bba90cb7f22b6a09a573b4a1993fd7de7d6b8046c408960c5f21a25e64ccb969d484b32ea3b3e19d6e4
+  checksum: 6d7f60fd01e3885bb334607f22b9cb1002e72da81dad2e672fef1b0d1a2f640b0f0ff5310369401488fac90c7a7f5d39c89fd18789af59c672c9b5aef4cade3e
   languageName: node
   linkType: hard
 
@@ -4430,14 +4430,14 @@ __metadata:
   version: 29.1.2
   resolution: "ts-jest@npm:29.1.2"
   dependencies:
-    bs-logger: 0.x
-    fast-json-stable-stringify: 2.x
-    jest-util: ^29.0.0
-    json5: ^2.2.3
-    lodash.memoize: 4.x
-    make-error: 1.x
-    semver: ^7.5.3
-    yargs-parser: ^21.0.1
+    bs-logger: "npm:0.x"
+    fast-json-stable-stringify: "npm:2.x"
+    jest-util: "npm:^29.0.0"
+    json5: "npm:^2.2.3"
+    lodash.memoize: "npm:4.x"
+    make-error: "npm:1.x"
+    semver: "npm:^7.5.3"
+    yargs-parser: "npm:^21.0.1"
   peerDependencies:
     "@babel/core": ">=7.0.0-beta.0 <8"
     "@jest/types": ^29.0.0
@@ -4455,7 +4455,7 @@ __metadata:
       optional: true
   bin:
     ts-jest: cli.js
-  checksum: 8/a0ce0affc1b716c78c9ab55837829c42cb04b753d174a5c796bb1ddf9f0379fc20647b76fbe30edb30d9b23181908138d6b4c51ef2ae5e187b66635c295cefd5
+  checksum: 5e40e7b933a1f3aa0d304d3c53913d1a7125fc79cd44e22b332f6e25dfe13008ddc7ac647066bb4f914d76083f7e8949f0bc156d793c30f3419f4ffd8180968b
   languageName: node
   linkType: hard
 
@@ -4524,13 +4524,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@5.3.3#~builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A5.3.3#optional!builtin<compat/typescript>":
   version: 5.3.3
-  resolution: "typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>::version=5.3.3&hash=e012d7"
+  resolution: "typescript@patch:typescript@npm%3A5.3.3#optional!builtin<compat/typescript>::version=5.3.3&hash=e012d7"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 8/4e604a9e107ce0c23b16a2f8d79d0531d4d8fe9ebbb7a8c395c66998c39892f0e0a071ef0b0d4e66420a8ec2b8d6cfd9cdb29ba24f25b37cba072e9282376df9
+  checksum: c93786fcc9a70718ba1e3819bab56064ead5817004d1b8186f8ca66165f3a2d0100fee91fa64c840dcd45f994ca5d615d8e1f566d39a7470fc1e014dbb4cf15d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add the `supplyDefaultsInJsDoc` setting

If a field has a default value, add its stringified representation to the JsDoc using the `@default` annotation.