### PR TITLE
Same Name File

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ export async function convertFromDirectory(settings: Partial<Settings>): Promise
   // TODO: remove fields from derived interfaces here
 
   for (const exportType of filesInDirectory.types) {
-    writeInterfaceFile(appSettings, exportType.typeFileName, filesInDirectory.types);
+    writeInterfaceFile(appSettings, exportType.typeFileName, filesInDirectory.types, `${exportType.typeFileLocation}/${exportType.typeFileName}`);
   }
 
   if (appSettings.indexAllToRoot || appSettings.flattenTree) {

--- a/src/writeInterfaceFile.ts
+++ b/src/writeInterfaceFile.ts
@@ -11,9 +11,10 @@ import { Settings, GenerateTypeFile } from './types';
 export async function writeInterfaceFile(
   settings: Settings,
   typeFileName: string,
-  generatedTypes: GenerateTypeFile[]
+  generatedTypes: GenerateTypeFile[],
+  fullPath: string
 ): Promise<undefined | string> {
-  const generatedFile = generatedTypes.find(x => x.typeFileName === typeFileName);
+  const generatedFile = generatedTypes.find(x => `${x.typeFileLocation}/${x.typeFileName}` === fullPath);
   if (generatedFile && generatedFile.fileContent && generatedFile.typeFileName) {
     let typeImports = '';
     if (settings.flattenTree) {


### PR DESCRIPTION
Hello,

I was using your package and face a few struggles with files that share the same name (`convertFromDirectory`), I made small change that seems to work for my specific use case (Just compare based on the full path).

TBH, Not sure if this breaks something or if goes in a direction different that the one you envisions for your project, if that's the case, apologies.

Regards.

---
tweak(same-file-name): Update to allow same file name when writing "writeInterfaceFile" from "convertFromDirectory"